### PR TITLE
ci: opt actions into node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   quality:
     name: Ruff, ty, and pytest

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -21,6 +21,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   prepare-release:
     name: Prepare release PR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ concurrency:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: Build release artifacts


### PR DESCRIPTION
## Summary

- Opt GitHub Actions JavaScript actions into Node.js 24 using FORCE_JAVASCRIPT_ACTIONS_TO_NODE24
- Applies to CI, prepare-release, and release workflows

## Validation

- Parsed workflow YAML
- uv run ruff format --check .
- uv run ruff check .
- uv run ty check
- uv run pytest