### PR TITLE
ci: add release bump choices

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -3,10 +3,15 @@ name: Prepare Release
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: "Version to prepare, for example: 0.1.4"
+      bump:
+        description: "Version part to bump"
         required: true
-        type: string
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
       notes:
         description: "Single changelog bullet"
         required: false
@@ -14,7 +19,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.version }}
+  group: ${{ github.workflow }}-${{ inputs.bump }}
   cancel-in-progress: true
 
 permissions:
@@ -48,16 +53,28 @@ jobs:
 
       - name: Prepare release files
         run: |
-          python scripts/bump-version.py "${{ inputs.version }}" --notes "${{ inputs.notes }}"
+          python scripts/bump-version.py --bump "${{ inputs.bump }}" --notes "${{ inputs.notes }}"
           uv lock
 
+      - name: Read prepared version
+        id: version
+        run: |
+          version="$(python - <<'PY'
+          import tomllib
+
+          with open("pyproject.toml", "rb") as pyproject:
+              print(tomllib.load(pyproject)["project"]["version"])
+          PY
+          )"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
       - name: Validate release artifacts
-        run: ./scripts/check-release.sh "${{ inputs.version }}"
+        run: ./scripts/check-release.sh "${{ steps.version.outputs.version }}"
 
       - name: Open release PR
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           branch="release-v${VERSION}"
           git config user.name "github-actions[bot]"

--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ Optionally assert the expected project version:
 ```
 
 Use the **Prepare Release** GitHub Action to open a release PR for an explicit version.
-The workflow bumps `pyproject.toml`, regenerates `uv.lock`, updates `CHANGELOG.md`, runs the
-release check, and opens a `release-vX.Y.Z` pull request. After merging the PR, publish by
-pushing the matching `vX.Y.Z` tag; the tag-based release workflow builds artifacts,
-publishes them to PyPI with the `UV_PUBLISH_TOKEN` GitHub secret, attaches the artifacts to
-the GitHub Release, and restarts the Hugging Face Space when the `HF_TOKEN` secret is
-configured.
+The workflow can bump `patch`, `minor`, or `major` from the current `pyproject.toml`
+version, regenerates `uv.lock`, updates `CHANGELOG.md`, runs the release check, and opens a
+`release-vX.Y.Z` pull request. After merging the PR, publish by pushing the matching
+`vX.Y.Z` tag; the tag-based release workflow builds artifacts, publishes them to PyPI with
+the `UV_PUBLISH_TOKEN` GitHub secret, attaches the artifacts to the GitHub Release, and
+restarts the Hugging Face Space when the `HF_TOKEN` secret is configured.
 
 ### Hugging Face Space Deployment
 

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -6,18 +6,54 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:[a-zA-Z0-9.-]+)?$")
+STABLE_VERSION_RE = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$")
 PROJECT_VERSION_RE = re.compile(r'(?m)^version = "([^"]+)"$')
+BUMP_PARTS = ("major", "minor", "patch")
 
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Bump project version and changelog.")
-    parser.add_argument("version", help="Version to prepare, for example: 0.1.4")
+    parser.add_argument("version", nargs="?", help="Version to prepare, for example: 0.1.4")
+    parser.add_argument(
+        "--bump",
+        choices=BUMP_PARTS,
+        help="Derive the next version by bumping the current project version.",
+    )
     parser.add_argument(
         "--notes",
         default="Prepare release.",
         help="Single bullet to include in the changelog entry.",
     )
     return parser.parse_args()
+
+
+def _project_version(pyproject: Path) -> str:
+    match = PROJECT_VERSION_RE.search(pyproject.read_text())
+    if match is None:
+        raise SystemExit("Could not find project version in pyproject.toml")
+    return match.group(1)
+
+
+def _bump_version(version: str, part: str) -> str:
+    match = STABLE_VERSION_RE.fullmatch(version)
+    if match is None:
+        raise SystemExit(f"Cannot {part}-bump non-stable version: {version}")
+
+    major = int(match.group("major"))
+    minor = int(match.group("minor"))
+    patch = int(match.group("patch"))
+
+    if part == "major":
+        major += 1
+        minor = 0
+        patch = 0
+    elif part == "minor":
+        minor += 1
+        patch = 0
+    else:
+        patch += 1
+
+    return f"{major}.{minor}.{patch}"
 
 
 def _replace_project_version(pyproject: Path, version: str) -> str:
@@ -51,11 +87,18 @@ def _update_changelog(changelog: Path, version: str, notes: str) -> None:
 
 def main() -> None:
     args = _parse_args()
-    version = args.version.strip()
+    pyproject = Path("pyproject.toml")
+
+    if bool(args.version) == bool(args.bump):
+        raise SystemExit("Specify exactly one of VERSION or --bump")
+
+    version = (
+        _bump_version(_project_version(pyproject), args.bump) if args.bump else args.version.strip()
+    )
     if VERSION_RE.fullmatch(version) is None:
         raise SystemExit(f"Invalid version: {version}")
 
-    previous_version = _replace_project_version(Path("pyproject.toml"), version)
+    previous_version = _replace_project_version(pyproject, version)
     if previous_version == version:
         raise SystemExit(f"pyproject.toml is already at version {version}")
 


### PR DESCRIPTION
## Summary

- Replace the Prepare Release typed version input with a patch/minor/major dropdown
- Derive the next version from pyproject.toml
- Keep direct explicit version support in scripts/bump-version.py for local use
- Document the updated release flow

## Validation

- Exercised patch/minor/major bumps in a temporary copy
- uv run ruff format --check .
- uv run ruff check .
- uv run ty check
- uv run pytest