### PR TITLE
ci: publish to PyPI with trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ concurrency:
 
 permissions:
   contents: write
+  id-token: write
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -47,14 +48,7 @@ jobs:
 
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags/')
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
-        run: |
-          if [ -z "${UV_PUBLISH_TOKEN}" ]; then
-            echo "Missing UV_PUBLISH_TOKEN repository secret." >&2
-            exit 1
-          fi
-          uv publish dist/*
+        run: uv publish --trusted-publishing automatic dist/*
 
       - name: Restart Hugging Face Space
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Summary

- Grant the release workflow OIDC id-token permission
- Publish with uv trusted publishing instead of UV_PUBLISH_TOKEN

## Validation

- Parsed workflow YAML
- uv run ruff format --check .
- uv run ruff check .
- uv run ty check
- uv run pytest