### PR TITLE
ci: simplify manual release flow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -73,7 +73,6 @@ jobs:
 
       - name: Open release PR
         env:
-          GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           branch="release-v${VERSION}"
@@ -84,29 +83,20 @@ jobs:
           git commit -m "chore: release ${VERSION}"
           git push --force-with-lease origin "${branch}"
 
-          body="$(cat <<EOF
-          ## Summary
+          pr_url="https://github.com/${GITHUB_REPOSITORY}/pull/new/${branch}"
 
-          - Bump hf-agentfinder to ${VERSION}
-          - Update uv.lock
-          - Update CHANGELOG.md
+          cat >> "${GITHUB_STEP_SUMMARY}" <<EOF
+          ## Release ${VERSION} prepared
 
-          ## Validation
+          Pushed branch \`${branch}\`.
 
-          - ./scripts/check-release.sh ${VERSION}
+          Open the release PR:
 
-          After merging, publish by pushing the tag:
+          ${pr_url}
 
-          \`\`\`bash
-          git tag v${VERSION}
-          git push origin v${VERSION}
-          \`\`\`
+          After merging the PR, run the **Release** workflow manually with version
+          \`${VERSION}\`, or push tag \`v${VERSION}\`.
           EOF
-          )"
 
-          existing_pr="$(gh pr list --head "${branch}" --base main --json number --jq '.[0].number')"
-          if [ -n "${existing_pr}" ]; then
-            gh pr edit "${existing_pr}" --title "chore: release ${VERSION}" --body "${body}"
-          else
-            gh pr create --base main --head "${branch}" --title "chore: release ${VERSION}" --body "${body}"
-          fi
+          echo "Release branch pushed: ${branch}"
+          echo "Open PR: ${pr_url}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,14 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish, for example: 0.1.4"
+        required: true
+        type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.version || '' }}
   cancel-in-progress: true
 
 permissions:
@@ -36,6 +41,27 @@ jobs:
         with:
           python-version: "3.14"
 
+      - name: Read project version
+        id: project
+        run: |
+          version="$(python - <<'PY'
+          import tomllib
+
+          with open("pyproject.toml", "rb") as pyproject:
+              print(tomllib.load(pyproject)["project"]["version"])
+          PY
+          )"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Validate manual publish version
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${{ inputs.version }}" != "${{ steps.project.outputs.version }}" ]; then
+            echo "Requested version ${{ inputs.version }} does not match pyproject.toml version ${{ steps.project.outputs.version }}." >&2
+            echo "Merge the matching release PR before publishing." >&2
+            exit 1
+          fi
+
       - name: Build and smoke-test release artifacts
         run: ./scripts/check-release.sh
 
@@ -47,11 +73,11 @@ jobs:
           if-no-files-found: error
 
       - name: Publish to PyPI
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         run: uv publish --trusted-publishing automatic dist/*
 
       - name: Restart Hugging Face Space
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
@@ -66,8 +92,9 @@ jobs:
           PY
 
       - name: Create GitHub release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: v${{ inputs.version || steps.project.outputs.version }}
           files: dist/*
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -58,13 +58,14 @@ Optionally assert the expected project version:
 ./scripts/check-release.sh 0.1.0
 ```
 
-Use the **Prepare Release** GitHub Action to open a release PR for an explicit version.
-The workflow can bump `patch`, `minor`, or `major` from the current `pyproject.toml`
-version, regenerates `uv.lock`, updates `CHANGELOG.md`, runs the release check, and opens a
-`release-vX.Y.Z` pull request. After merging the PR, publish by pushing the matching
-`vX.Y.Z` tag; the tag-based release workflow builds artifacts, publishes them to PyPI with
-the `UV_PUBLISH_TOKEN` GitHub secret, attaches the artifacts to the GitHub Release, and
-restarts the Hugging Face Space when the `HF_TOKEN` secret is configured.
+Use the **Prepare Release** GitHub Action to prepare a release branch. The workflow can bump
+`patch`, `minor`, or `major` from the current `pyproject.toml` version, regenerates
+`uv.lock`, updates `CHANGELOG.md`, runs the release check, pushes `release-vX.Y.Z`, and
+prints the PR URL in the workflow summary. After merging the PR, publish by running the
+**Release** workflow with the merged version, or by pushing the matching `vX.Y.Z` tag. The
+release workflow builds artifacts, publishes them to PyPI using trusted publishing, attaches
+the artifacts to the GitHub Release, and restarts the Hugging Face Space when the `HF_TOKEN`
+secret is configured.
 
 ### Hugging Face Space Deployment
 


### PR DESCRIPTION
## Summary

- Stop Prepare Release from trying to create PRs with GITHUB_TOKEN, which the org blocks
- Make Prepare Release push the release branch and print the manual PR URL instead
- Allow the Release workflow to be manually dispatched with a version to publish the already-merged release
- Keep tag-push publishing supported

## Validation

- Parsed workflow YAML
- uv run ruff format --check .
- uv run ruff check .
- uv run ty check
- uv run pytest