### PR TITLE
ci: create releases with gh cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,13 +65,6 @@ jobs:
       - name: Build and smoke-test release artifacts
         run: ./scripts/check-release.sh
 
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v5
-        with:
-          name: hf-agentfinder-dist
-          path: dist/*
-          if-no-files-found: error
-
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         run: uv publish --trusted-publishing automatic dist/*
@@ -93,8 +86,16 @@ jobs:
 
       - name: Create GitHub release
         if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ inputs.version || steps.project.outputs.version }}
-          files: dist/*
-          generate_release_notes: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version || steps.project.outputs.version }}
+        run: |
+          tag="v${VERSION}"
+          if gh release view "${tag}" >/dev/null 2>&1; then
+            gh release upload "${tag}" dist/* --clobber
+          else
+            gh release create "${tag}" dist/* \
+              --title "${tag}" \
+              --generate-notes \
+              --target "${GITHUB_SHA}"
+          fi


### PR DESCRIPTION
## Summary

- Remove Node-based upload-artifact/action-gh-release steps from the release workflow
- Attach dist artifacts directly to the GitHub Release with gh CLI
- Keep PyPI trusted publishing and HF Space restart unchanged

## Validation

- Parsed workflow YAML
- uv run ruff format --check .
- uv run ruff check .
- uv run ty check
- uv run pytest