### PR TITLE
Release 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.5](https://github.com/huggingface/agentfinder/releases/tag/v0.1.5) - 2026-05-25
+
+### Changes
+
+- Make compatible as hf extension.
+
 ## [0.1.4](https://github.com/huggingface/agentfinder/releases/tag/v0.1.4) - 2026-05-12
 
 ### Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hf-agentfinder"
-version = "0.1.4"
+version = "0.1.5"
 description = "Agent Finder registry adapter for Hugging Face Spaces"
 readme = "README.md"
 requires-python = ">=3.10.0"

--- a/uv.lock
+++ b/uv.lock
@@ -121,7 +121,7 @@ wheels = [
 
 [[package]]
 name = "hf-agentfinder"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- Bump package version to 0.1.5
- Update CHANGELOG.md with the release note from the Prepare Release workflow
- Regenerate uv.lock

After this PR is merged, run the **Release** workflow manually with version `0.1.5`, or push tag `v0.1.5`, to publish to PyPI and create the GitHub release.