### PR TITLE
Remove PyPI release environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,6 @@ jobs:
   build:
     name: Build release artifacts
     runs-on: ubuntu-latest
-    environment: pypi
 
     steps:
       - name: Confirm manual release


### PR DESCRIPTION
## Summary

- Remove the GitHub Environment from the Release job so trusted publishing matches the existing PyPI trusted publisher configured with Environment: Any.

## Validation

- One-line workflow-only change