### PR TITLE
Fix HF extension entry point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,9 @@ fastagent.jsonl
 data.ms/
 meilisearch
 
+# Private/local spec checkout used for implementation review.
+spec/ard-spec/
+
 # uv lockfile is intentionally committed.
 # uv.lock
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ A small ARD registry adapter for Hugging Face Skills and Spaces.
 
 It exposes Hugging Face discovery as:
 
-- a CLI: `discover search "remove background from image"`
-- version introspection: `discover --version`
-- a hosted ARD registry client: `discover search "remove background from image"`
-- a generic ARD registry client: `discover search --registry-url https://registry.example "remove background from image"`
+- a CLI: `hf-discover search "remove background from image"`
+- version introspection: `hf-discover --version`
+- a hosted ARD registry client: `hf-discover search "remove background from image"`
+- a generic ARD registry client: `hf-discover search --registry-url https://registry.example "remove background from image"`
 - a primary ARD REST API combining indexed Hugging Face Skills and Hugging Face
   Spaces: `POST /search`
 - a targeted nested Hugging Face Spaces registry: `POST /registries/huggingface/spaces/search`
@@ -23,12 +23,12 @@ that want targeted Spaces-only discovery or explicit registry traversal.
 
 ### Space Search and Skill Generation
 
-`discover` exposes Hugging Face Spaces semantic search in the primary `/search` endpoint
+`hf-discover` exposes Hugging Face Spaces semantic search in the primary `/search` endpoint
 and as a targeted nested registry backend at `/registries/huggingface/spaces/search`.
 Search requests use the Hub's agent-oriented semantic search (`agents=true`) and return
 matching Spaces as ARD catalog entries. By default, results can include generated
-`application/ai-skill` artifacts, plus `application/mcp-server+json` entries for matching
-Spaces tagged `mcp-server`.
+`application/ai-skill` artifacts, plus `application/mcp-server-card+json` entries for
+matching Spaces tagged `mcp-server`.
 
 Search responses strictly include only Spaces whose runtime stage is `RUNNING`, so returned
 entries are limited to Spaces that are currently ready to serve traffic. The runtime stage
@@ -43,14 +43,16 @@ For clients that want raw Space descriptors instead of skills, request
 `application/vnd.huggingface.space+json` from either the primary search endpoint or the
 nested Spaces search endpoint.
 
-Requests for `application/mcp-server+json` add `filter=mcp-server` to the downstream Hub
-search and return MCP server catalog entries that point at this adapter's generated
-`server.json` descriptor route. Fetching that descriptor performs a direct Hugging Face
-Space info lookup, verifies the Space is tagged `mcp-server`, and synthesizes an MCP
-Registry-style document whose `remotes[]` contains the Space's Gradio
-`streamable-http` MCP endpoint. When Hub runtime metadata includes a Space domain, that
-domain is used for app and MCP URLs; otherwise the adapter falls back to the standard
-`.hf.space` slug convention.
+Requests for `application/mcp-server-card+json` add `filter=mcp-server` to the downstream
+Hub search and return MCP server card catalog entries that point at this adapter's
+generated `server.json` descriptor route. The legacy `application/mcp-server+json` filter
+is accepted as a transition alias, but new responses use the `*-card+json` media type
+from the pinned ARD spec. Fetching that descriptor performs a direct Hugging Face Space
+info lookup, verifies the Space is tagged `mcp-server`, and synthesizes an MCP
+Registry-style document whose `remotes[]` contains the Space's Gradio `streamable-http`
+MCP endpoint. When Hub runtime metadata includes a Space domain, that domain is used for
+app and MCP URLs; otherwise the adapter falls back to the standard `.hf.space` slug
+convention.
 
 The CLI queries the hosted hf-discover deployment by default and can query any
 ARD-compatible registry by passing `--registry-url`. The value may be either a registry
@@ -72,12 +74,21 @@ at the skill directory, not the contained `SKILL.md` file. Generated Space skill
 single-file artifacts materialized by this adapter and continue to point at the generated
 `/skills/huggingface/{owner}/{space}/SKILL.md` URL.
 
-For `application/vnd.huggingface.space+json` and `application/mcp-server+json`, primary
-search routes directly to the Spaces backend because those media types are Space-specific.
+For `application/vnd.huggingface.space+json` and `application/mcp-server-card+json`,
+primary search routes directly to the Spaces backend because those media types are
+Space-specific.
 
 The registry uses the ARD v0.5 search envelope: artifact type constraints are
 expressed as `query.filter.type`, response entries use the catalog `type` field, and
-Hugging Face entries use domain-anchored `urn:ai:hf.co:...` identifiers.
+Hugging Face entries use domain-anchored `urn:ai:hf.co:...` identifiers. Catalog entry
+models enforce the v0.5 strict value-or-reference rule, domain-anchored `urn:ai:<fqdn>:...`
+identifiers, and integer 0-100 relevance scores.
+
+Structured filters use the ARD v0.5 field-path semantics for exact matching after
+retrieval: scalar filter values are treated like single-item arrays, values within one
+filter key are ORed, different filter keys are ANDed, arrays on entries match when any
+item matches, nested paths such as `metadata.sourceType` are supported, and `publisher`
+is derived from the entry identifier's publisher domain.
 
 The primary server exposes `GET /.well-known/ai-catalog.json` as an ARD discovery
 document. It advertises the primary Hugging Face Discover registry and the nested
@@ -99,24 +110,34 @@ can use the referral for a follow-up Spaces-only search.
 
 ### Challenge Registry Server
 
-`discover challenge serve` runs a deterministic local fixture registry for client
+`hf-discover challenge serve` runs a deterministic local fixture registry for client
 development. It returns mixed ARD result types, including skills, MCP servers, A2A
 agents, ai-catalog bundles, registry entries, referrals, empty registries, and nested
 registries. Use it to test clients that need to follow registry trees and fetch referenced
 artifacts without relying on Hugging Face or Meilisearch services.
 
-`discover challenge search` queries a running challenge registry and defaults to
+`hf-discover challenge search` queries a running challenge registry and defaults to
 requesting referrals, making it a convenient CLI path for agents that need to practice
-ARD traversal. The generic `discover search` command defaults to the hosted
+ARD traversal. The generic `hf-discover search` command defaults to the hosted
 deployment and also accepts `--registry-url` and `--federation none|referrals|auto`. When
 registry-backed commands are run with `--json`, the CLI prints the registry's raw
 `SearchResponse` body so clients can inspect exact `results`, `referrals`, `type`,
 `url`, `data`, and `pageToken` fields returned by the server.
 
+The challenge registry uses the same catalog-entry model and field-path filtering helper
+as the primary server. Both registries expose `POST /explore` and return `501 Not
+Implemented`, matching the ARD v0.5 behavior for registries that do not implement the
+optional Explore facets API.
+
 ### Specification References
 
-`spec/ard.md` remains the local ARD source-of-truth. The AI Catalog draft
-reference can be refreshed from the upstream `Agent-Card/ai-catalog` repository with
+`spec/ard.md` remains the committed local ARD orientation snapshot. When a private pinned
+upstream spec checkout is available locally at `spec/ard-spec/`, use its `spec/ard.md`,
+ADRs, schemas, and conformance CLI as the authoritative artifacts for implementation
+review. That checkout is intentionally gitignored.
+
+The AI Catalog draft reference can be refreshed from the upstream `Agent-Card/ai-catalog`
+repository with
 `./scripts/update-ai-catalog-spec.sh`, which copies the latest Markdown and JSON assets
 from its `specification/` folder into `spec/ai-catalog/`.
 
@@ -125,11 +146,10 @@ The vendored `spec/ai-catalog/` snapshot currently tracks the pre-merge content 
 
 ### Roadmap
 
-The next `hf-discover` version is expected to expand ARD v0.5 structured
-filter support. Today the HTTP server accepts `query.filter` and routes `type` filters,
-with additional exact-match field filters applied after retrieval; the CLI exposes only
-the common media-type path through `--kind`. Planned work includes a clearer CLI surface
-for arbitrary structured filters and improved server-side handling/pushdown for common
+The next `hf-discover` version is expected to expand the CLI surface for arbitrary ARD
+structured filters. Today the HTTP server accepts `query.filter` and applies exact-match
+field-path filters after retrieval; the CLI exposes only the common media-type path
+through `--kind`. Planned work includes improved server-side handling/pushdown for common
 fields such as tags and Space SDK.
 
 It will also use "auto" federation.
@@ -194,7 +214,7 @@ idea and points to the artifacts that contain the operational evidence. For deta
 
 ## Usage
 
-The examples below use the standalone `discover` command form.
+The examples below use the standalone `hf-discover` command form.
 
 `--kind skill` requests AI-skill results. In the combined registry this includes indexed,
 directory-style Hugging Face Skills from Meilisearch and generated single-file Space skill
@@ -203,17 +223,17 @@ MCP server entries for Spaces tagged `mcp-server`. `--kind all` asks for the def
 view.
 
 ```bash
-> discover --version
-> discover search "generate image" --limit 5
-> discover search "generate image" --kind skill --json
-> discover search "generate image" --kind space --json
-> discover search "generate image" --kind mcp --json
-> discover mcp-server-json mcp-tools/FLUX.1-Kontext-Dev
-> discover search --registry-url https://registry.example "generate image" --kind skill --json
-> discover search "generate image" --kind space --local
-> discover serve --port 8080
-> discover challenge serve --port 8090
-> discover challenge search "find tools and registries" --federation referrals --json
+> hf-discover --version
+> hf-discover search "generate image" --limit 5
+> hf-discover search "generate image" --kind skill --json
+> hf-discover search "generate image" --kind space --json
+> hf-discover search "generate image" --kind mcp --json
+> hf-discover mcp-server-json mcp-tools/FLUX.1-Kontext-Dev
+> hf-discover search --registry-url https://registry.example "generate image" --kind skill --json
+> hf-discover search "generate image" --kind space --local
+> hf-discover serve --port 8080
+> hf-discover challenge serve --port 8090
+> hf-discover challenge search "find tools and registries" --federation referrals --json
 ```
 
 ### Recommended `hf` extension usage
@@ -226,9 +246,9 @@ For Hugging Face CLI users, the recommended install path is as an `hf` extension
 > hf discover search "generate image" --kind space --limit 5
 ```
 
-The project still documents examples as `discover ...` because the same CLI is also
+The project still documents examples as `hf-discover ...` because the same CLI is also
 available as a standalone Python console script. When installed as an extension, replace
-`discover` with `hf discover`.
+`hf-discover` with `hf discover`.
 
 ```bash
 > curl -X POST http://localhost:8080/search \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 ]
 
 [project.scripts]
-discover = "discover.cli:app"
+hf-discover = "discover.cli:app"
 
 [dependency-groups]
 dev = [

--- a/scripts/check-release.sh
+++ b/scripts/check-release.sh
@@ -93,6 +93,6 @@ trap 'rm -rf "${tmpdir}"' EXIT
 echo "==> Smoke-installing wheel in a clean virtual environment"
 uv venv "${tmpdir}/venv" --python 3.14
 uv pip install --python "${tmpdir}/venv/bin/python" dist/*.whl
-"${tmpdir}/venv/bin/discover" --help >/dev/null
+"${tmpdir}/venv/bin/hf-discover" --help >/dev/null
 
 echo "==> Release artifacts are ready in dist/"

--- a/src/discover/challenge.py
+++ b/src/discover/challenge.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import PlainTextResponse
 
+from discover.filters import apply_entry_filters
 from discover.hf_spaces import AI_SKILL_MEDIA_TYPE, MCP_SERVER_MEDIA_TYPE
 from discover.models import CatalogEntry, SearchRequest, SearchResponse, SearchResult
 
@@ -19,7 +20,7 @@ def _base_url(request: Request) -> str:
     return str(request.base_url).rstrip("/")
 
 
-def _score(entry: SearchResult, query: str, index: int) -> float:
+def _score(entry: SearchResult, query: str, index: int) -> int:
     haystack = " ".join(
         [
             entry.displayName,
@@ -30,10 +31,10 @@ def _score(entry: SearchResult, query: str, index: int) -> float:
     ).lower()
     terms = [term for term in query.lower().split() if term]
     matches = sum(1 for term in terms if term in haystack)
-    return max(1.0, entry.score + matches * 5 - index)
+    return round(min(100, max(1, entry.score + matches * 5 - index)))
 
 
-def _skill_result(base_url: str, name: str, description: str, score: float) -> SearchResult:
+def _skill_result(base_url: str, name: str, description: str, score: int) -> SearchResult:
     return SearchResult(
         identifier=f"urn:ai:{CHALLENGE_PUBLISHER}:challenge:skill:{name}",
         displayName=name,
@@ -48,7 +49,7 @@ def _skill_result(base_url: str, name: str, description: str, score: float) -> S
     )
 
 
-def _mcp_result(base_url: str, name: str, description: str, score: float) -> SearchResult:
+def _mcp_result(base_url: str, name: str, description: str, score: int) -> SearchResult:
     return SearchResult(
         identifier=f"urn:ai:{CHALLENGE_PUBLISHER}:challenge:mcp:{name}",
         displayName=f"{name} MCP Server",
@@ -74,7 +75,7 @@ def _mcp_result(base_url: str, name: str, description: str, score: float) -> Sea
     )
 
 
-def _a2a_result(name: str, description: str, score: float) -> SearchResult:
+def _a2a_result(name: str, description: str, score: int) -> SearchResult:
     return SearchResult(
         identifier=f"urn:ai:{CHALLENGE_PUBLISHER}:challenge:a2a:{name}",
         displayName=f"{name} A2A Agent",
@@ -94,7 +95,7 @@ def _a2a_result(name: str, description: str, score: float) -> SearchResult:
     )
 
 
-def _catalog_result(base_url: str, score: float) -> SearchResult:
+def _catalog_result(base_url: str, score: int) -> SearchResult:
     return SearchResult(
         identifier=f"urn:ai:{CHALLENGE_PUBLISHER}:challenge:catalog:bundle",
         displayName="Challenge Bundle Catalog",
@@ -131,7 +132,7 @@ def _registry_result(
     name: str,
     path: str,
     description: str,
-    score: float,
+    score: int,
 ) -> SearchResult:
     return SearchResult(
         identifier=f"urn:ai:{CHALLENGE_PUBLISHER}:challenge:registry:{name}",
@@ -251,11 +252,7 @@ def _filter_results(
     results: list[SearchResult],
     request: SearchRequest,
 ) -> list[SearchResult]:
-    raw_type_filter = request.query.filter.get("type")
-    type_filter = raw_type_filter if isinstance(raw_type_filter, list) else [raw_type_filter]
-    filtered = [
-        result for result in results if raw_type_filter is None or result.type in type_filter
-    ]
+    filtered = apply_entry_filters(results, request.query.filter)
     ranked = [
         result.model_copy(update={"score": _score(result, request.query.text, index)})
         for index, result in enumerate(filtered)
@@ -414,6 +411,12 @@ def _add_search_routes(app: FastAPI) -> None:
         return _search_response(request_body, base_url=_base_url(request), results=[])
 
 
+def _add_explore_route(app: FastAPI) -> None:
+    @app.post("/explore")
+    async def explore() -> None:
+        raise HTTPException(status_code=501, detail="Explore is not implemented")
+
+
 def _add_artifact_routes(app: FastAPI) -> None:
     @app.get("/artifacts/skills/{name}/SKILL.md", response_class=PlainTextResponse)
     async def skill_artifact(name: str) -> PlainTextResponse:
@@ -443,5 +446,6 @@ def create_challenge_app() -> FastAPI:
     _add_health_routes(app)
     _add_catalog_routes(app)
     _add_search_routes(app)
+    _add_explore_route(app)
     _add_artifact_routes(app)
     return app

--- a/src/discover/cli.py
+++ b/src/discover/cli.py
@@ -43,26 +43,26 @@ SPEC_HELP = """Find agent-ready Hugging Face Skills, Spaces, Servers.
 Search the registry and output ARD results as JSON or human readable tables.
 
 Find background removal MCP Servers:
-discover search "remove image background" --json --kind mcp
+hf-discover search "remove image background" --json --kind mcp
 
 Find AI Skills or MCP Servers to train a vision model:
-discover search "train a vision model" --json
+hf-discover search "train a vision model" --json
 
 Use --kind skill|space|mcp to search for a specific result view:
   skill: AI skills, including indexed Hugging Face Skills and generated Space SKILL.md wrappers
   space: raw Hugging Face Space descriptors
   mcp: MCP server entries for Spaces tagged mcp-server
-Use discover search --help for more information.
+Use hf-discover search --help for more information.
 
 """
 
 app = typer.Typer(
     help=f"ARD registry adapters.\n\n{SPEC_HELP}",
     # epilog=(
-    #     "Challenge quickstart: run `discover challenge serve --port 8090`, then "
-    #     '`discover challenge search "find tools" --federation referrals --json`. '
-    #     "Hosted registry search: `discover search QUERY`. "
-    #     "Generic registry search: `discover search --registry-url URL QUERY`."
+    #     "Challenge quickstart: run `hf-discover challenge serve --port 8090`, then "
+    #     '`hf-discover challenge search "find tools" --federation referrals --json`. '
+    #     "Hosted registry search: `hf-discover search QUERY`. "
+    #     "Generic registry search: `hf-discover search --registry-url URL QUERY`."
     # ),
     add_completion=False,
     invoke_without_command=True,
@@ -234,7 +234,7 @@ def _project_version() -> str:
 
 
 def _print_version() -> None:
-    console.print(f"discover {_project_version()}")
+    console.print(f"hf-discover {_project_version()}")
 
 
 @app.callback()
@@ -583,7 +583,7 @@ def challenge_search(
 ) -> None:
     """Query a running challenge server.
 
-    Defaults to the local `discover challenge serve` endpoint and requests referrals.
+    Defaults to the local `hf-discover challenge serve` endpoint and requests referrals.
     Reading agents should use --json to see the raw SearchResponse, follow referrals and
     application/ai-registry+json result URLs, fetch url artifacts, and parse inline data.
     """

--- a/src/discover/filters.py
+++ b/src/discover/filters.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from discover.models import SearchResult
+
+URN_AI_PUBLISHER_PARTS = 3
+TYPE_FILTER_ALIASES = {
+    "application/mcp-server+json": "application/mcp-server-card+json",
+}
+
+
+def publisher_from_identifier(identifier: str) -> str | None:
+    parts = identifier.split(":")
+    if len(parts) >= URN_AI_PUBLISHER_PARTS and parts[0] == "urn" and parts[1] == "ai":
+        return parts[2]
+    return None
+
+
+def entry_values_at_path(value: Any, path: list[str]) -> list[Any]:
+    if not path:
+        return value if isinstance(value, list) else [value]
+    if isinstance(value, list):
+        return [item for child in value for item in entry_values_at_path(child, path)]
+    if not isinstance(value, dict):
+        return []
+    current = value.get(path[0])
+    return [] if current is None else entry_values_at_path(current, path[1:])
+
+
+def entry_filter_values(entry: SearchResult, field: str) -> list[Any]:
+    if field == "publisher":
+        publisher = publisher_from_identifier(entry.identifier)
+        return [] if publisher is None else [publisher]
+
+    payload = entry.model_dump(exclude_none=True)
+    return entry_values_at_path(payload, field.split("."))
+
+
+def matches_filter(entry: SearchResult, raw_filter: dict[str, Any]) -> bool:
+    for field, expected in raw_filter.items():
+        expected_values = expected if isinstance(expected, list) else [expected]
+        if field == "type":
+            expected_values = [
+                TYPE_FILTER_ALIASES.get(value, value) if isinstance(value, str) else value
+                for value in expected_values
+            ]
+        actual_values = entry_filter_values(entry, field)
+        if not any(
+            actual == expected_value
+            for actual in actual_values
+            for expected_value in expected_values
+        ):
+            return False
+    return True
+
+
+def apply_entry_filters(
+    results: list[SearchResult],
+    raw_filter: dict[str, Any],
+) -> list[SearchResult]:
+    if not raw_filter:
+        return results
+    return [result for result in results if matches_filter(result, raw_filter)]

--- a/src/discover/hf_skills.py
+++ b/src/discover/hf_skills.py
@@ -44,6 +44,10 @@ def _ranking_score(hit: dict[str, Any]) -> float:
     return 0.0
 
 
+def _score_percentage(ranking_score: float) -> int:
+    return round(min(100.0, max(0.0, ranking_score * 100)))
+
+
 def _skill_key(hit: dict[str, Any]) -> str:
     return _string(hit, "skill") or _string(hit, "path") or _string(hit, "id") or "unknown"
 
@@ -133,7 +137,7 @@ def _search_result_from_hit(hit: dict[str, Any]) -> SearchResult:
         description=description,
         tags=["huggingface", "skills"],
         metadata=metadata,
-        score=ranking_score * 100,
+        score=_score_percentage(ranking_score),
         source=HF_SKILLS_SOURCE,
     )
 

--- a/src/discover/hf_spaces.py
+++ b/src/discover/hf_spaces.py
@@ -13,7 +13,8 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
 AI_SKILL_MEDIA_TYPE = "application/ai-skill"
-MCP_SERVER_MEDIA_TYPE = "application/mcp-server+json"
+MCP_SERVER_MEDIA_TYPE = "application/mcp-server-card+json"
+LEGACY_MCP_SERVER_MEDIA_TYPE = "application/mcp-server+json"
 MCP_SERVER_SCHEMA_URL = (
     "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json"
 )
@@ -155,10 +156,10 @@ def _space_tags(space: SpaceSearchResultLike) -> list[str]:
     return list(dict.fromkeys(tags))
 
 
-def _score(space: SpaceSearchResultLike) -> float:
+def _score(space: SpaceSearchResultLike) -> int:
     if space.semantic_relevancy_score is None:
-        return 0.0
-    return space.semantic_relevancy_score * 100
+        return 0
+    return round(min(100.0, max(0.0, space.semantic_relevancy_score * 100)))
 
 
 def _runtime_stage(space: SpaceSearchResultLike) -> str | None:

--- a/src/discover/models.py
+++ b/src/discover/models.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+import re
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 FederationMode = Literal["auto", "referrals", "none"]
+URN_AI_IDENTIFIER_RE = re.compile(
+    r"^urn:ai:"
+    r"(?P<publisher>(?=.{1,253}:)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+"
+    r"[A-Za-z]{2,63})"
+    r":[A-Za-z0-9._~!$&'()*+,;=@%-]+"
+    r"(?::[A-Za-z0-9._~!$&'()*+,;=@%-]+)*$"
+)
 
 
 class CatalogEntry(BaseModel):
@@ -26,6 +34,16 @@ class CatalogEntry(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
     trustManifest: dict[str, Any] | None = None
 
+    @field_validator("identifier")
+    @classmethod
+    def validate_identifier(cls, value: str) -> str:
+        if URN_AI_IDENTIFIER_RE.fullmatch(value) is None:
+            raise ValueError(
+                "identifier must use domain-anchored ARD URN format "
+                "urn:ai:<publisher-fqdn>:<namespace-or-name>[:<agent-name>...]"
+            )
+        return value
+
     @model_validator(mode="after")
     def validate_value_or_reference(self) -> CatalogEntry:
         if (self.url is None) == (self.data is None):
@@ -44,12 +62,12 @@ class SearchQuery(BaseModel):
         default_factory=dict,
         description=(
             "Structured field-path constraints. Use `type` to constrain artifact media "
-            "types, for example `{'type': ['application/mcp-server+json']}`."
+            "types, for example `{'type': ['application/mcp-server-card+json']}`."
         ),
         examples=[
             {"type": ["application/ai-skill"]},
             {"type": ["application/vnd.huggingface.space+json"]},
-            {"type": ["application/mcp-server+json"]},
+            {"type": ["application/mcp-server-card+json"]},
         ],
     )
 
@@ -70,7 +88,7 @@ class SearchRequest(BaseModel):
 
 
 class SearchResult(CatalogEntry):
-    score: float
+    score: int = Field(ge=0, le=100)
     source: str
 
 

--- a/src/discover/server.py
+++ b/src/discover/server.py
@@ -14,10 +14,12 @@ from fastapi.openapi.models import Example
 from fastapi.responses import JSONResponse, PlainTextResponse
 from starlette.concurrency import run_in_threadpool
 
+from discover.filters import apply_entry_filters
 from discover.hf_skills import search_hf_skills
 from discover.hf_spaces import (
     AI_SKILL_MEDIA_TYPE,
     HF_SPACE_MEDIA_TYPE,
+    LEGACY_MCP_SERVER_MEDIA_TYPE,
     MCP_SERVER_MEDIA_TYPE,
     SPACES_URL_PREFIX,
     SpaceResultKind,
@@ -39,7 +41,6 @@ AI_REGISTRY_MEDIA_TYPE = "application/ai-registry+json"
 HF_ENDPOINT = "https://huggingface.co"
 HTTP_NOT_FOUND = 404
 PUBLIC_BASE_URL_ENV = "DISCOVER_PUBLIC_BASE_URL"
-URN_AI_PUBLISHER_PARTS = 3
 SEARCH_REQUEST_EXAMPLES: dict[str, Example] = {
     "skill": Example(
         summary="Generated AI skill results",
@@ -69,14 +70,15 @@ SEARCH_REQUEST_EXAMPLES: dict[str, Example] = {
     "mcp": Example(
         summary="MCP server discovery request",
         description=(
-            "`application/mcp-server+json` returns MCP server entries for Hugging Face Spaces "
-            "tagged `mcp-server`. The Hub search request is constrained with "
-            "`filter=mcp-server&agents=true`."
+            "`application/mcp-server-card+json` returns MCP server card entries for Hugging "
+            "Face Spaces tagged `mcp-server`. The Hub search request is constrained with "
+            "`filter=mcp-server&agents=true`. The legacy `application/mcp-server+json` filter "
+            "is accepted as a transition alias."
         ),
         value={
             "query": {
                 "text": "image generation mcp server",
-                "filter": {"type": ["application/mcp-server+json"]},
+                "filter": {"type": ["application/mcp-server-card+json"]},
             },
             "pageSize": 5,
         },
@@ -229,6 +231,7 @@ def _result_kind(artifact_type: str) -> SpaceResultKind | None:
         AI_SKILL_MEDIA_TYPE: "skill",
         HF_SPACE_MEDIA_TYPE: "space",
         MCP_SERVER_MEDIA_TYPE: "mcp",
+        LEGACY_MCP_SERVER_MEDIA_TYPE: "mcp",
     }
     return kinds.get(artifact_type)
 
@@ -264,50 +267,8 @@ def _includes_skill_index(artifact_types: list[str]) -> bool:
     return not artifact_types or AI_SKILL_MEDIA_TYPE in artifact_types
 
 
-def _publisher_from_identifier(identifier: str) -> str | None:
-    parts = identifier.split(":")
-    if len(parts) >= URN_AI_PUBLISHER_PARTS and parts[0] == "urn" and parts[1] == "ai":
-        return parts[2]
-    return None
-
-
-def _entry_values_at_path(value: Any, path: list[str]) -> list[Any]:
-    if not path:
-        return value if isinstance(value, list) else [value]
-    if isinstance(value, list):
-        return [item for child in value for item in _entry_values_at_path(child, path)]
-    if not isinstance(value, dict):
-        return []
-    current = value.get(path[0])
-    return [] if current is None else _entry_values_at_path(current, path[1:])
-
-
-def _entry_filter_values(entry: SearchResult, field: str) -> list[Any]:
-    if field == "publisher":
-        publisher = _publisher_from_identifier(entry.identifier)
-        return [] if publisher is None else [publisher]
-
-    payload = entry.model_dump(exclude_none=True)
-    return _entry_values_at_path(payload, field.split("."))
-
-
-def _matches_filter(entry: SearchResult, raw_filter: dict[str, Any]) -> bool:
-    for field, expected in raw_filter.items():
-        expected_values = expected if isinstance(expected, list) else [expected]
-        actual_values = _entry_filter_values(entry, field)
-        if not any(
-            actual == expected_value
-            for actual in actual_values
-            for expected_value in expected_values
-        ):
-            return False
-    return True
-
-
 def _apply_entry_filters(results: list[SearchResult], request: SearchRequest) -> list[SearchResult]:
-    if not request.query.filter:
-        return results
-    return [result for result in results if _matches_filter(result, request.query.filter)]
+    return apply_entry_filters(results, request.query.filter)
 
 
 def _bearer_token(value: str | None) -> str | None:
@@ -663,6 +624,12 @@ def _add_catalog_route(app: FastAPI) -> None:
         )
 
 
+def _add_explore_route(app: FastAPI) -> None:
+    @app.post("/explore")
+    async def explore() -> None:
+        raise HTTPException(status_code=501, detail="Explore is not implemented")
+
+
 def create_app(
     *,
     include_non_running: bool = False,
@@ -740,6 +707,7 @@ def create_app(
             search_spaces=search_spaces,
         )
 
+    _add_explore_route(app)
     _add_spaces_search_route(
         app,
         include_non_running=include_non_running,

--- a/tests/test_challenge.py
+++ b/tests/test_challenge.py
@@ -53,6 +53,29 @@ def test_challenge_search_filters_by_media_type() -> None:
     assert {result["type"] for result in results} == {MCP_SERVER_MEDIA_TYPE}
 
 
+def test_challenge_search_filters_by_publisher_and_metadata_field_path() -> None:
+    client = TestClient(create_challenge_app())
+
+    response = client.post(
+        "/search",
+        json={
+            "query": {
+                "text": "tool server",
+                "filter": {
+                    "publisher": "discover.dev",
+                    "metadata.sourceType": "challenge-mcp",
+                },
+            },
+            "pageSize": 10,
+        },
+    )
+
+    assert response.status_code == 200
+    results = response.json()["results"]
+    assert results
+    assert {result["type"] for result in results} == {MCP_SERVER_MEDIA_TYPE}
+
+
 def test_challenge_nested_registry_refers_to_deep_registry() -> None:
     client = TestClient(create_challenge_app())
 
@@ -93,3 +116,11 @@ def test_challenge_artifact_routes_are_fetchable() -> None:
     assert mcp_response.json()["tools"][0]["name"] == "challenge_echo"
     assert catalog_response.status_code == 200
     assert catalog_response.json()["host"]["displayName"] == "ARD Challenge Registry"
+
+
+def test_challenge_explore_returns_not_implemented() -> None:
+    client = TestClient(create_challenge_app())
+
+    response = client.post("/explore", json={"query": {}, "resultType": {"facets": []}})
+
+    assert response.status_code == 501

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -125,7 +125,7 @@ def test_registry_response_error_message_explains_missing_v5_type_field() -> Non
             {
                 "results": [
                     {
-                        "identifier": "urn:ai:example:skill",
+                        "identifier": "urn:ai:example.com:skill",
                         "displayName": "Example Skill",
                         "url": "https://example.com/SKILL.md",
                         "score": 91,
@@ -151,7 +151,7 @@ def test_registry_response_error_message_summarizes_many_missing_fields() -> Non
             {
                 "results": [
                     {
-                        "identifier": f"urn:ai:example:skill:{index}",
+                        "identifier": f"urn:ai:example.com:skill:{index}",
                         "displayName": f"Example Skill {index}",
                         "url": f"https://example.com/{index}/SKILL.md",
                         "score": 91,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,21 +46,23 @@ def test_version_option_prints_installed_project_version() -> None:
     result = CliRunner().invoke(app, ["--version"])
 
     assert result.exit_code == 0
-    assert result.output == f"discover {version('hf-discover')}\n"
+    assert result.output == f"hf-discover {version('hf-discover')}\n"
 
 
 def test_version_command_prints_installed_project_version() -> None:
     result = CliRunner().invoke(app, ["version"])
 
     assert result.exit_code == 0
-    assert result.output == f"discover {version('hf-discover')}\n"
+    assert result.output == f"hf-discover {version('hf-discover')}\n"
 
 
 def test_package_exposes_hf_extension_console_script() -> None:
     scripts = entry_points(group="console_scripts")
 
-    assert scripts["discover"].value == "discover.cli:app"
-    assert [script.name for script in scripts if script.value == "discover.cli:app"] == ["discover"]
+    assert scripts["hf-discover"].value == "discover.cli:app"
+    assert [script.name for script in scripts if script.value == "discover.cli:app"] == [
+        "hf-discover",
+    ]
 
 
 def test_search_commands_default_to_hosted_registry_urls() -> None:

--- a/tests/test_hf_spaces.py
+++ b/tests/test_hf_spaces.py
@@ -13,7 +13,7 @@ from typing_extensions import override
 
 from discover import cli, server
 from discover.hf_search import HfSemanticSpaceSearcher
-from discover.hf_skills import search_hf_skills
+from discover.hf_skills import _search_result_from_hit, search_hf_skills
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 from discover.hf_spaces import (
     AI_SKILL_MEDIA_TYPE,
     HF_SPACE_MEDIA_TYPE,
+    LEGACY_MCP_SERVER_MEDIA_TYPE,
     MCP_SERVER_MEDIA_TYPE,
     SPACES_URL_PREFIX,
     SpaceResultKind,
@@ -106,12 +107,12 @@ class RegistrySearchHandler(BaseHTTPRequestHandler):
         response = {
             "results": [
                 {
-                    "identifier": "urn:test:skill:image",
+                    "identifier": "urn:ai:example.com:skill:image",
                     "displayName": "Image Skill",
                     "type": "application/ai-skill",
                     "url": "https://example.com/SKILL.md",
                     "description": "Edit images.",
-                    "score": 42.0,
+                    "score": 42,
                     "source": "test-registry",
                 }
             ]
@@ -244,7 +245,8 @@ class RecordingSearch:
                 type=media_type,
                 url=url,
                 description="Edit images with a Space.",
-                score=91.0,
+                metadata={"sourceType": "huggingface-space"},
+                score=91,
                 source="https://huggingface.co",
             )
         ]
@@ -263,7 +265,7 @@ class RecordingSkillsSearch:
                 type=AI_SKILL_MEDIA_TYPE,
                 url="https://github.com/huggingface/skills/blob/main/skills/hf-cli/SKILL.md",
                 description="Use the Hugging Face CLI.",
-                score=98.0,
+                score=98,
                 source="https://github.com/huggingface/skills",
             )
         ]
@@ -330,7 +332,7 @@ def test_space_to_search_result_defaults_to_skill_wrapper() -> None:
     assert result.type == AI_SKILL_MEDIA_TYPE
     assert result.url == (f"{SPACES_URL_PREFIX}/skills/huggingface/alice/cool.space/SKILL.md")
     assert result.description == "Generate and edit images."
-    assert result.score == 91.0
+    assert result.score == 91
     assert result.source == "https://huggingface.co"
     assert result.metadata["spaceId"] == "alice/cool.space"
     assert result.metadata["runtimeStage"] == "RUNNING"
@@ -338,6 +340,22 @@ def test_space_to_search_result_defaults_to_skill_wrapper() -> None:
         result.metadata["agentsMdUrl"] == "https://huggingface.co/spaces/alice/cool.space/agents.md"
     )
     assert "image-to-image" in result.tags
+
+
+def test_space_search_result_score_is_clamped_to_relevance_percentage() -> None:
+    high_score = Space(
+        id="alice/high-score",
+        runtime=Runtime(stage="RUNNING"),
+        semantic_relevancy_score=1.5,
+    )
+    negative_score = Space(
+        id="alice/negative-score",
+        runtime=Runtime(stage="RUNNING"),
+        semantic_relevancy_score=-0.1,
+    )
+
+    assert space_to_search_result(cast("SpaceSearchResultLike", high_score)).score == 100
+    assert space_to_search_result(cast("SpaceSearchResultLike", negative_score)).score == 0
 
 
 def test_space_to_search_result_can_return_generic_space_descriptor() -> None:
@@ -665,9 +683,23 @@ def test_hf_skills_search_queries_meili_and_groups_section_hits_by_skill() -> No
     assert len(results) == 1
     assert results[0].identifier == "urn:ai:github.com:huggingface:skills:hf-cli"
     assert results[0].url == "https://github.com/huggingface/skills/tree/main/skills/hf-cli"
-    assert results[0].score == 95.0
+    assert results[0].score == 95
     assert results[0].metadata["path"] == "skills/hf-cli"
     assert results[0].metadata["title"] == "Repository uploads"
+
+
+def test_hf_skills_search_clamps_ranking_score_to_relevance_percentage() -> None:
+    result = _search_result_from_hit(
+        {
+            "id": "hf-cli-high",
+            "skill": "hf-cli",
+            "skill_name": "hf-cli",
+            "path": "skills/hf-cli/SKILL.md",
+            "_rankingScore": 1.5,
+        }
+    )
+
+    assert result.score == 100
 
 
 def test_hf_semantic_space_searcher_sends_agents_filter_and_token() -> None:
@@ -775,6 +807,73 @@ def test_discover_search_routes_mcp_media_type_to_spaces_only() -> None:
     assert search_spaces.queries == [("tool server", 3, "mcp", SPACES_URL_PREFIX)]
     assert [result.displayName for result in response.results] == ["Image Tool"]
     assert [result.type for result in response.results] == [MCP_SERVER_MEDIA_TYPE]
+
+
+def test_discover_search_accepts_legacy_mcp_media_type_alias() -> None:
+    search_spaces = RecordingSearch()
+
+    response = search_discover(
+        SearchRequest(
+            query=SearchQuery(
+                text="tool server",
+                filter={"type": [LEGACY_MCP_SERVER_MEDIA_TYPE]},
+            ),
+            pageSize=3,
+        ),
+        search_skills=lambda query, *, limit=10: [],
+        search_spaces=search_spaces,
+    )
+
+    assert search_spaces.queries == [("tool server", 3, "mcp", SPACES_URL_PREFIX)]
+    assert [result.type for result in response.results] == [MCP_SERVER_MEDIA_TYPE]
+
+
+def test_discover_search_applies_scalar_publisher_and_metadata_filters() -> None:
+    search_spaces = RecordingSearch()
+
+    response = search_discover(
+        SearchRequest(
+            query=SearchQuery(
+                text="tool server",
+                filter={
+                    "type": MCP_SERVER_MEDIA_TYPE,
+                    "publisher": "hf.co",
+                    "metadata.sourceType": "huggingface-space",
+                },
+            ),
+            pageSize=3,
+        ),
+        search_skills=lambda query, *, limit=10: [],
+        search_spaces=search_spaces,
+    )
+
+    assert [result.type for result in response.results] == [MCP_SERVER_MEDIA_TYPE]
+
+
+def test_discover_search_filters_by_capability_array_values() -> None:
+    def search_spaces(query: str, **kwargs: object) -> list[SearchResult]:
+        return [
+            SearchResult(
+                identifier="urn:ai:hf.co:mcp:space:alice:image-tool",
+                displayName="Image Tool",
+                type=MCP_SERVER_MEDIA_TYPE,
+                url="https://example.com/server.json",
+                capabilities=["ImageTool", "EditTool"],
+                score=91,
+                source="https://huggingface.co",
+            )
+        ]
+
+    response = search_discover(
+        SearchRequest(
+            query=SearchQuery(text="image editing", filter={"capabilities": ["EditTool"]}),
+            pageSize=3,
+        ),
+        search_skills=lambda query, *, limit=10: [],
+        search_spaces=search_spaces,
+    )
+
+    assert [result.displayName for result in response.results] == ["Image Tool"]
 
 
 def test_discover_search_returns_spaces_referral_when_requested() -> None:
@@ -908,6 +1007,14 @@ def test_public_base_url_config_controls_advertised_registry_urls() -> None:
     )
 
 
+def test_primary_server_explore_returns_not_implemented() -> None:
+    client = TestClient(create_app())
+
+    response = client.post("/explore", json={"query": {}, "resultType": {"facets": []}})
+
+    assert response.status_code == 501
+
+
 def test_hf_token_from_headers_uses_precedence_order() -> None:
     selected = hf_token_from_headers(
         {
@@ -1012,7 +1119,9 @@ def test_openapi_search_request_examples_hint_at_media_types() -> None:
     assert examples["huggingface-space"]["value"]["query"]["filter"]["type"] == [
         "application/vnd.huggingface.space+json"
     ]
-    assert examples["mcp"]["value"]["query"]["filter"]["type"] == ["application/mcp-server+json"]
+    assert examples["mcp"]["value"]["query"]["filter"]["type"] == [
+        "application/mcp-server-card+json"
+    ]
 
 
 def test_agents_md_route_fetches_in_threadpool(monkeypatch) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from discover.hf_spaces import AI_SKILL_MEDIA_TYPE
+from discover.models import CatalogEntry, SearchResult
+
+
+def test_catalog_entry_requires_domain_anchored_urn_identifier() -> None:
+    entry = CatalogEntry(
+        identifier="urn:ai:example.com:skill:image-editor",
+        displayName="Image Editor",
+        type=AI_SKILL_MEDIA_TYPE,
+        url="https://example.com/SKILL.md",
+    )
+
+    assert entry.identifier == "urn:ai:example.com:skill:image-editor"
+
+
+@pytest.mark.parametrize(
+    "identifier",
+    [
+        "urn:test:skill:image-editor",
+        "urn:ai:example:skill:image-editor",
+        "https://example.com/skill/image-editor",
+    ],
+)
+def test_catalog_entry_rejects_non_ard_identifiers(identifier: str) -> None:
+    with pytest.raises(ValidationError):
+        CatalogEntry(
+            identifier=identifier,
+            displayName="Image Editor",
+            type=AI_SKILL_MEDIA_TYPE,
+            url="https://example.com/SKILL.md",
+        )
+
+
+def test_search_result_score_must_be_relevance_percentage() -> None:
+    with pytest.raises(ValidationError):
+        SearchResult(
+            identifier="urn:ai:example.com:skill:image-editor",
+            displayName="Image Editor",
+            type=AI_SKILL_MEDIA_TYPE,
+            url="https://example.com/SKILL.md",
+            score=101,
+            source="https://example.com",
+        )


### PR DESCRIPTION
## Summary
- expose only the required `hf-discover` console script for `hf extensions install huggingface/hf-discover`
- remove the standalone `discover` console script
- keep `discover` only as the Python import package name
- update CLI help/version text and release smoke check to use `hf-discover`

## Validation
- `uv run ruff check src/discover/cli.py tests/test_cli.py`
- `uv run python -m pytest tests/test_cli.py`
- `git diff --cached --check`

After merge, release a patch version so the HF extension install can resolve the required console script.
