### PR TITLE
Fix Space startup command

### DIFF
--- a/deploy/huggingface-space/start-discover.sh
+++ b/deploy/huggingface-space/start-discover.sh
@@ -213,4 +213,4 @@ if copy_meilisearch; then
   ingest_skills
 fi
 
-exec uvx --refresh --from hf-discover discover serve --host 0.0.0.0 --port "${PORT}"
+exec uvx --refresh --from hf-discover hf-discover serve --host 0.0.0.0 --port "${PORT}"


### PR DESCRIPTION
## Summary
- run hf-discover serve in the Space startup script now that hf-discover is the only console script

## Validation
- hot-uploaded the fixed Space payload to evalstate/hf-discover
- restarted the Space and verified /health reports all registries configured
- verified POST /search returns results from the live Space

This fixes the runtime error where package hf-discover no longer provides a discover executable.
