### PR TITLE
Use huggingface.co ARD publisher identifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ meilisearch
 
 # Private/local spec checkout used for implementation review.
 spec/ard-spec/
+spec/ai-catalog-spec/
 
 # uv lockfile is intentionally committed.
 # uv.lock

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Space-specific.
 
 The registry uses the ARD v0.5 search envelope: artifact type constraints are
 expressed as `query.filter.type`, response entries use the catalog `type` field, and
-Hugging Face entries use domain-anchored `urn:ai:hf.co:...` identifiers. Catalog entry
+Hugging Face entries use domain-anchored `urn:ai:huggingface.co:...` identifiers. Catalog entry
 models enforce the v0.5 strict value-or-reference rule, domain-anchored `urn:ai:<fqdn>:...`
 identifiers, and integer 0-100 relevance scores.
 
@@ -93,7 +93,7 @@ is derived from the entry identifier's publisher domain.
 The primary server exposes `GET /.well-known/ai-catalog.json` as an ARD discovery
 document. It advertises the primary Hugging Face Discover registry and the nested
 Spaces registry as `application/ai-registry+json` entries using v0.5 `type` fields and
-domain-anchored `urn:ai:hf.co:...` identifiers.
+domain-anchored `urn:ai:huggingface.co:...` identifiers.
 
 By default, advertised registry, generated Space skill, and generated MCP `server.json`
 URLs are derived from the incoming request base URL, because those URLs point at
@@ -141,8 +141,8 @@ repository with
 `./scripts/update-ai-catalog-spec.sh`, which copies the latest Markdown and JSON assets
 from its `specification/` folder into `spec/ai-catalog/`.
 
-The vendored `spec/ai-catalog/` snapshot currently tracks the pre-merge content from
-`Agent-Card/ai-catalog` PR #37, which updates catalog entries from `mediaType` to `type`.
+The vendored `spec/ai-catalog/` snapshot tracks the upstream `Agent-Card/ai-catalog`
+`specification/` folder at the commit recorded in `spec/ai-catalog/SOURCE.md`.
 
 ### Roadmap
 

--- a/spec/ai-catalog/SOURCE.md
+++ b/spec/ai-catalog/SOURCE.md
@@ -1,6 +1,6 @@
 # AI Catalog upstream source
 
-Downloaded from `Agent-Card/ai-catalog` at ref `758088e84b4c84a3aa793402bcb649eb148152d7`.
+Downloaded from `Agent-Card/ai-catalog` at ref `28f5309dfde3933b9dda3d7cf2f635bc6415272f`.
 
 Source folder:
 

--- a/spec/ai-catalog/ai-catalog.md
+++ b/spec/ai-catalog/ai-catalog.md
@@ -117,19 +117,19 @@ For example, a minimal catalog listing three AI artifacts:
     {
       "identifier": "urn:example:skill:code-review",
       "displayName": "Code Review Assistant",
-      "type": "application/ai-skills+zip",
+      "mediaType": "application/agentskill+zip",
       "url": "https://skills.example.com/code-review/skill.zip"
     },
     {
       "identifier": "urn:example:mcp:weather",
       "displayName": "Weather Service",
-      "type": "application/mcp-server+json",
+      "mediaType": "application/mcp-server-card+json",
       "url": "https://api.example.com/.well-known/mcp/server-card.json"
     },
     {
       "identifier": "urn:example:a2a:research",
       "displayName": "Research Assistant",
-      "type": "application/a2a-agent-card+json",
+      "mediaType": "application/a2a-agent-card+json",
       "url": "https://agents.example.com/researchAssistant"
     }
   ]
@@ -197,22 +197,17 @@ It MUST contain the following members:
 `displayName`
 : A string containing a human-readable name for the artifact.
 
-`type`
-: A string containing the identifier that specifies the type of the
-  referenced artifact. This field is an open text format, so any string value is accepted. However, to ensure interoperability, it is RECOMMENDED to use one of the following recognized "known types" in the ecosystem when applicable, partitioned by their respective governance boundaries:
+`mediaType`
+: A string containing the media type that identifies the type of the
+  referenced artifact. This is the mechanism by which clients
+  determine what kind of AI artifact the entry represents. Well-known
+  values include (but are not limited to):
 
-  **Core Protocol Types (Governed by the AI Catalog WG):**
   - `application/ai-catalog+json` — a nested AI Catalog
-  - `application/agent-card+json` — reserved for a generic Agent Card format
-
-  **Integrated Ecosystem & Third-Party Types (Governed externally):**
   - `application/a2a-agent-card+json` — an A2A Agent Card
-  - `application/mcp-server+json` — an MCP Server Card
-  - `application/ai-skills+zip` — an AI Skill bundle (ZIP archive)
-  - `application/ai-skills+gzip` — an AI Skill bundle (gzipped tarball)
-  - `text/markdown; profile=ai-skill` — an AI Skill defined in a standard Markdown file
-
-  These values are designed to align with official IANA media type registration standards. Standard ecosystem types use registered structured syntax suffixes (`+json`, `+zip`, `+gzip`). For generic payload formats (like `text/markdown`), the standard `profile` parameter is used to specify the semantic schema (e.g., `profile=ai-skill`). For any new or custom types not listed here, it is up to the specific client implementation to handle them correctly.
+  - `application/mcp-server-card+json` — an MCP Server Card
+  - Any other media type defined by a protocol specification (e.g.,
+    `application/agentskill+zip` for skill definitions)
 
 A Catalog Entry MUST contain exactly one of the following members to
 provide the artifact content:
@@ -220,11 +215,11 @@ provide the artifact content:
 `url`
 : A string containing a URL where the full artifact document can be
   retrieved. The document served at this URL SHOULD be served with
-  the media type declared in the `type` field.
+  the media type declared in the `mediaType` field.
 
 `data`
 : A JSON value containing the complete artifact document inline. The
-  structure of this value is determined by the `type` field and
+  structure of this value is determined by the `mediaType` field and
   is opaque to this specification.
 
 The following members are OPTIONAL:
@@ -286,7 +281,7 @@ For example, a catalog listing two versions of the same agent:
       "identifier": "urn:acme:agent:finance",
       "displayName": "Acme Finance Agent",
       "version": "2.1.0",
-      "type": "application/a2a-agent-card+json",
+      "mediaType": "application/a2a-agent-card+json",
       "url": "https://api.acme-corp.com/agents/finance/v2.1.json",
       "updatedAt": "2026-03-15T10:00:00Z"
     },
@@ -294,7 +289,7 @@ For example, a catalog listing two versions of the same agent:
       "identifier": "urn:acme:agent:finance",
       "displayName": "Acme Finance Agent",
       "version": "2.0.0",
-      "type": "application/a2a-agent-card+json",
+      "mediaType": "application/a2a-agent-card+json",
       "url": "https://api.acme-corp.com/agents/finance/v2.0.json",
       "updatedAt": "2026-01-20T08:00:00Z"
     }
@@ -346,7 +341,8 @@ A Trust Manifest MUST contain:
 `identity`
 : A string containing a globally unique URI [[RFC3986]] that serves as
   the primary subject identifier for this artifact. This SHOULD be a
-  DID, SPIFFE ID, or URL.
+  DID, SPIFFE ID, or URL; these are illustrative and the set of
+  identity schemes is open.
 
 When a Trust Manifest appears within a Catalog Entry, the `identity`
 field MUST match the entry's `identifier` field. This binding ensures trust
@@ -654,13 +650,13 @@ For each attestation in the `attestations` array:
 # Organizing Catalogs
 
 As catalogs grow, a flat list of entries becomes unwieldy. Because any
-catalog entry can have a `type` of `application/ai-catalog+json`,
+catalog entry can have a `mediaType` of `application/ai-catalog+json`,
 catalogs are naturally composable — an entry can reference or inline
 another AI Catalog, creating a hierarchy of any depth.
 
 ## Nested Catalog Entries
 
-A catalog entry whose `type` is `application/ai-catalog+json`
+A catalog entry whose `mediaType` is `application/ai-catalog+json`
 references (via `url`) or embeds (via `data`) another AI Catalog
 document. This mechanism supports two complementary use cases:
 
@@ -680,19 +676,19 @@ its own `host` and entries:
     {
       "identifier": "urn:acme:catalog:finance",
       "displayName": "Finance Services",
-      "type": "application/ai-catalog+json",
+      "mediaType": "application/ai-catalog+json",
       "url": "https://acme.com/catalogs/finance.json"
     },
     {
       "identifier": "urn:acme:catalog:ml",
       "displayName": "ML Models",
-      "type": "application/ai-catalog+json",
+      "mediaType": "application/ai-catalog+json",
       "url": "https://acme.com/catalogs/ml.json"
     },
     {
       "identifier": "urn:acme:catalog:devops",
       "displayName": "DevOps Tools",
-      "type": "application/ai-catalog+json",
+      "mediaType": "application/ai-catalog+json",
       "url": "https://acme.com/catalogs/devops.json"
     }
   ]
@@ -708,7 +704,7 @@ agent, an MCP server, and a dataset together:
 {
   "identifier": "urn:acme:plugin:finance-suite",
   "displayName": "Finance Plugin",
-  "type": "application/ai-catalog+json",
+  "mediaType": "application/ai-catalog+json",
   "url": "https://acme.com/plugins/finance-suite.json",
   "publisher": {
     "identifier": "did:web:acme-corp.com",
@@ -900,7 +896,7 @@ A conformant Minimal Catalog is a JSON document with media type
 
 - `specVersion` — the specification version string
 - `entries` — an array of Catalog Entry objects, each containing at
-  minimum `identifier`, `displayName`, `type`, and exactly one of `url` or
+  minimum `identifier`, `displayName`, `mediaType`, and exactly one of `url` or
   `data`
 
 All other fields (`host`, `publisher`, `trustManifest`,
@@ -1046,7 +1042,7 @@ MUST treat it as untrusted input. In particular:
 - Content with HTML or script-capable media types MUST be sandboxed
   and MUST NOT be executed in the consumer's security context.
 - Consumers SHOULD validate that the `data` content is well-formed
-  JSON (or the expected format for the declared `type`) before
+  JSON (or the expected format for the declared `mediaType`) before
   processing.
 
 ## Privacy Considerations
@@ -1075,7 +1071,7 @@ classDiagram
     class CatalogEntry {
         identifier string
         displayName string
-        type string
+        mediaType string
         url | data
         version string
         publisher Publisher
@@ -1100,7 +1096,7 @@ classDiagram
     class Attestation {
         type string
         uri string
-        type string
+        mediaType string
         digest string
     }
     class ProvenanceLink {
@@ -1229,7 +1225,7 @@ HostInfo = {
 CatalogEntry = {
   identifier: text,
   displayName: text,
-  type: text,
+  mediaType: text,
   (url: text // data: any),
   ? version: text,
   ? description: text,
@@ -1272,7 +1268,7 @@ TrustSchema = {
 Attestation = {
   type: text,
   uri: text,
-  type: text,
+  mediaType: text,
   ? digest: text,
   ? size: uint,
   ? description: text
@@ -1306,7 +1302,7 @@ artifact types including a nested catalog packaging related artifacts:
       "identifier": "urn:acme:agent:finance-a2a",
       "displayName": "Acme Finance A2A Agent",
       "version": "2.1.0",
-      "type": "application/a2a-agent-card+json",
+      "mediaType": "application/a2a-agent-card+json",
       "url": "https://api.acme-corp.com/agents/finance.json",
       "description": "A2A agent for financial workflows.",
       "tags": ["finance", "a2a"],
@@ -1339,7 +1335,7 @@ artifact types including a nested catalog packaging related artifacts:
       "identifier": "urn:acme:server:finance-mcp",
       "displayName": "Acme Finance MCP Server",
       "version": "1.4.0",
-      "type": "application/mcp-server+json",
+      "mediaType": "application/mcp-server-card+json",
       "url": "https://api.acme-corp.com/.well-known/mcp/server-card.json",
       "description": "MCP server with finance tools.",
       "tags": ["finance", "mcp"],
@@ -1348,7 +1344,7 @@ artifact types including a nested catalog packaging related artifacts:
     {
       "identifier": "urn:acme:plugin:finance-suite",
       "displayName": "Acme Finance Suite",
-      "type": "application/ai-catalog+json",
+      "mediaType": "application/ai-catalog+json",
       "description": "A2A agent + MCP server + dataset for finance workflows.",
       "tags": ["finance", "suite"],
       "data": {
@@ -1357,19 +1353,19 @@ artifact types including a nested catalog packaging related artifacts:
           {
             "identifier": "urn:acme:agent:finance-a2a",
             "displayName": "Finance A2A Agent",
-            "type": "application/a2a-agent-card+json",
+            "mediaType": "application/a2a-agent-card+json",
             "url": "https://api.acme-corp.com/agents/finance.json"
           },
           {
             "identifier": "urn:acme:server:finance-mcp",
             "displayName": "Finance MCP Server",
-            "type": "application/mcp-server+json",
+            "mediaType": "application/mcp-server-card+json",
             "url": "https://api.acme-corp.com/.well-known/mcp/server-card.json"
           },
           {
             "identifier": "urn:acme:data:market-2026q1",
             "displayName": "Market Dataset Q1 2026",
-            "type": "application/parquet",
+            "mediaType": "application/parquet",
             "url": "https://data.acme-corp.com/market-2026q1.parquet",
             "trustManifest": {
               "identity": "urn:acme:data:market-2026q1",
@@ -1413,14 +1409,14 @@ document:
       "identifier": "urn:acme:agent:assistant",
       "displayName": "Acme Corporate Assistant",
       "version": "3.0.0",
-      "type": "application/a2a-agent-card+json",
+      "mediaType": "application/a2a-agent-card+json",
       "url": "https://api.acme-corp.com/agents/assistant.json",
       "description": "General-purpose corporate assistant agent."
     },
     {
       "identifier": "urn:acme:catalog:finance",
       "displayName": "Finance Services",
-      "type": "application/ai-catalog+json",
+      "mediaType": "application/ai-catalog+json",
       "url": "https://acme-corp.com/catalogs/finance.json",
       "description": "Financial agents, MCP servers, and datasets.",
       "tags": ["finance", "trading", "compliance"]
@@ -1428,7 +1424,7 @@ document:
     {
       "identifier": "urn:acme:catalog:engineering",
       "displayName": "Engineering Tools",
-      "type": "application/ai-catalog+json",
+      "mediaType": "application/ai-catalog+json",
       "url": "https://acme-corp.com/catalogs/engineering.json",
       "description": "CI/CD agents, code review tools, and DevOps servers.",
       "tags": ["engineering", "devops", "ci-cd"]
@@ -1436,7 +1432,7 @@ document:
     {
       "identifier": "urn:acme:catalog:ml-models",
       "displayName": "ML Models",
-      "type": "application/ai-catalog+json",
+      "mediaType": "application/ai-catalog+json",
       "url": "https://acme-corp.com/catalogs/ml-models.json",
       "description": "Model cards and inference endpoints.",
       "tags": ["ml", "models", "inference"]
@@ -1460,7 +1456,7 @@ containing both protocol-specific entries:
 {
   "identifier": "urn:acme:agent:finance",
   "displayName": "Acme Finance Agent",
-  "type": "application/ai-catalog+json",
+  "mediaType": "application/ai-catalog+json",
   "description": "Finance agent accessible via both MCP and A2A protocols.",
   "tags": ["finance", "dual-protocol"],
   "publisher": {
@@ -1473,13 +1469,13 @@ containing both protocol-specific entries:
       {
         "identifier": "urn:acme:agent:finance:mcp",
         "displayName": "Acme Finance MCP Server",
-        "type": "application/mcp-server+json",
+        "mediaType": "application/mcp-server-card+json",
         "url": "https://api.acme-corp.com/.well-known/mcp/server-card.json"
       },
       {
         "identifier": "urn:acme:agent:finance:a2a",
         "displayName": "Acme Finance A2A Agent",
-        "type": "application/a2a-agent-card+json",
+        "mediaType": "application/a2a-agent-card+json",
         "url": "https://api.acme-corp.com/agents/finance"
       }
     ]
@@ -1512,7 +1508,7 @@ and replication using existing container infrastructure.
 ## Logical Format vs. Physical Distribution
 
 The AI Catalog specification defines a **logical format**: a JSON
-document with `entries`, `displayName`, `type`, and `trustManifest`
+document with `entries`, `displayName`, `mediaType`, and `trustManifest`
 fields that are immediately meaningful to anyone working with AI
 artifacts. Authors write simple JSON. APIs serve simple JSON. Clients
 consume simple JSON.
@@ -1557,8 +1553,8 @@ concepts to their OCI physical equivalents:
 | AI Catalog (Logical) | OCI (Physical) |
 |:---|:---|
 | AI Catalog document | OCI Image Index with `artifactType: "application/ai-catalog+json"` |
-| Catalog Entry | OCI Image Manifest with `artifactType` set to the entry's `type` |
-| Entry `type` | Manifest `artifactType` field |
+| Catalog Entry | OCI Image Manifest with `artifactType` set to the entry's `mediaType` |
+| Entry `mediaType` | Manifest `artifactType` field |
 | Entry artifact content | Manifest `layers[0]` blob (the protocol-specific document) |
 | Entry metadata (name, tags, publisher) | Manifest `config` blob and/or `annotations` |
 | Nested Catalog Entry | Nested OCI Image Index referenced from the parent index |
@@ -1624,11 +1620,11 @@ authored by hand:
 ```json
 {
   "schemaVersion": 2,
-  "type": "application/vnd.oci.image.index.v1+json",
+  "mediaType": "application/vnd.oci.image.index.v1+json",
   "artifactType": "application/ai-catalog+json",
   "manifests": [
     {
-      "type": "application/vnd.oci.image.manifest.v1+json",
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
       "digest": "sha256:aaa111...",
       "size": 1024,
       "artifactType": "application/a2a-agent-card+json",
@@ -1638,10 +1634,10 @@ authored by hand:
       }
     },
     {
-      "type": "application/vnd.oci.image.manifest.v1+json",
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
       "digest": "sha256:bbb222...",
       "size": 512,
-      "artifactType": "application/mcp-server+json",
+      "artifactType": "application/mcp-server-card+json",
       "annotations": {
         "ai-catalog.identifier": "urn:acme:server:finance-mcp",
         "ai-catalog.displayName": "Acme Finance MCP Server"
@@ -1690,7 +1686,7 @@ tradeoffs are:
 | Concern | Logical-first (this spec) | OCI-native |
 |:---|:---|:---|
 | Authoring | Write simple JSON with domain vocabulary | Write JSON conforming to OCI Manifest schema |
-| Vocabulary | `entries`, `displayName`, `type`, `trustManifest` | `manifests`, `layers`, `config`, `annotations` |
+| Vocabulary | `entries`, `displayName`, `mediaType`, `trustManifest` | `manifests`, `layers`, `config`, `annotations` |
 | Minimum viable serving | Static JSON file at any URL (optionally well-known) | OCI registry or static OCI layout |
 | Signing | Detached JWS in logical format; Cosign/Notation in OCI | Cosign/Notation only |
 | Content integrity | Optional digests in Trust Manifest | Guaranteed by OCI content-addressing |
@@ -1770,7 +1766,7 @@ identity, trust verification, and cross-ecosystem discoverability.
 ## MCP Server as Catalog Entry
 
 An MCP server listed in the Registry maps to a Catalog Entry whose
-`url` points to the `server.json` document and whose `type`
+`url` points to the `server.json` document and whose `mediaType`
 reflects the Registry format:
 
 ```json
@@ -1778,7 +1774,7 @@ reflects the Registry format:
   "identifier": "urn:mcp:io.modelcontextprotocol.anonymous/brave-search",
   "displayName": "Brave Search",
   "version": "1.0.2",
-  "type": "application/mcp-server+json",
+  "mediaType": "application/json",
   "url": "https://registry.modelcontextprotocol.io/servers/brave-search/server.json",
   "description": "MCP server for Brave Search API integration",
   "tags": ["search", "brave", "web"],
@@ -1818,7 +1814,7 @@ catalog entry for discovery and trust evaluation, then retrieves the
 > **Note:** This example uses `application/json` because the MCP
 > Registry has not registered a dedicated media type for `server.json`.
 > When referencing an MCP Server Card (SEP-1649) instead, use
-> `application/mcp-server+json` — see
+> `application/mcp-server-card+json` — see
 > [Relationship to MCP Server Cards](#relationship-to-mcp-server-cards-sep-1649).
 
 ## MCP Registry as AI Catalog
@@ -1841,7 +1837,7 @@ agents, skills, and other artifacts:
       "identifier": "urn:mcp:io.modelcontextprotocol.anonymous/brave-search",
       "displayName": "Brave Search",
       "version": "1.0.2",
-      "type": "application/mcp-server+json",
+      "mediaType": "application/json",
       "url": "https://registry.modelcontextprotocol.io/servers/brave-search/server.json",
       "description": "MCP server for Brave Search API integration",
       "tags": ["search", "brave"]
@@ -1850,7 +1846,7 @@ agents, skills, and other artifacts:
       "identifier": "urn:mcp:io.github.modelcontextprotocol/filesystem",
       "displayName": "Filesystem",
       "version": "1.0.2",
-      "type": "application/mcp-server+json",
+      "mediaType": "application/json",
       "url": "https://registry.modelcontextprotocol.io/servers/filesystem/server.json",
       "description": "MCP server for filesystem operations",
       "tags": ["filesystem", "files"]
@@ -1859,7 +1855,7 @@ agents, skills, and other artifacts:
       "identifier": "urn:mcp:io.github.example/weather-mcp",
       "displayName": "Weather",
       "version": "0.5.0",
-      "type": "application/mcp-server+json",
+      "mediaType": "application/json",
       "url": "https://registry.modelcontextprotocol.io/servers/weather/server.json",
       "description": "Python MCP server for weather data access",
       "tags": ["weather", "python"],
@@ -1886,7 +1882,7 @@ https://api.acme-corp.com/.well-known/ai-catalog.json
 ```
 
 Clients and crawlers discover the catalog via the well-known URL,
-find entries by `type`, and fetch the referenced artifacts for
+find entries by `mediaType`, and fetch the referenced artifacts for
 operational details — whether those are MCP Server Cards, Registry
 `server.json` documents, or other AI artifact formats.
 
@@ -1944,7 +1940,7 @@ server can reference the Server Card as its artifact content:
 {
   "identifier": "urn:mcp:example.com:finance-server",
   "displayName": "Acme Finance MCP Server",
-  "type": "application/mcp-server+json",
+  "mediaType": "application/mcp-server+json",
   "url": "https://api.acme-corp.com/.well-known/mcp/server-card.json",
   "description": "MCP server for financial data and trading tools",
   "tags": ["finance", "mcp"],
@@ -1975,7 +1971,7 @@ A client discovering MCP servers follows this flow:
 
 1. Fetch `/.well-known/ai-catalog.json` to discover all artifacts on
    a domain (MCP servers, A2A agents, plugins, etc.).
-2. Filter entries by `type` to find MCP servers.
+2. Filter entries by `mediaType` to find MCP servers.
 3. Evaluate the Trust Manifest for publisher identity and attestations.
 4. Fetch the Server Card at the entry's `url` for operational details
    (transport, capabilities, tools, authentication).
@@ -2037,7 +2033,7 @@ plugins/
 | Plugin `homepage` | Entry `metadata.homepage` |
 | Plugin `.claude-plugin/plugin.json` | The artifact content (referenced via `url`) |
 | *(not in marketplace)* | Entry `trustManifest` (identity, attestations) |
-| *(not in marketplace)* | Entry `type` |
+| *(not in marketplace)* | Entry `mediaType` |
 | Centralized marketplace repo | AI Catalog (decentralized, any URL) |
 
 ## Source Types
@@ -2076,7 +2072,7 @@ maps to an AI Catalog where each plugin is an entry:
     {
       "identifier": "urn:claude-plugin:anthropic:agent-sdk-dev",
       "displayName": "agent-sdk-dev",
-      "type": "application/vnd.anthropic.claude-plugin+json",
+      "mediaType": "application/vnd.anthropic.claude-plugin+json",
       "url": "https://github.com/anthropics/claude-plugins-official/tree/main/plugins/agent-sdk-dev",
       "description": "Development kit for working with the Claude Agent SDK",
       "tags": ["development"],
@@ -2091,7 +2087,7 @@ maps to an AI Catalog where each plugin is an entry:
     {
       "identifier": "urn:claude-plugin:adspirer:ads-agent",
       "displayName": "adspirer-ads-agent",
-      "type": "application/vnd.anthropic.claude-plugin+json",
+      "mediaType": "application/vnd.anthropic.claude-plugin+json",
       "url": "https://github.com/amekala/adspirer-mcp-plugin.git",
       "description": "Cross-platform ad management for Google Ads, Meta Ads, TikTok Ads, and LinkedIn Ads.",
       "tags": ["productivity", "ads"],
@@ -2112,7 +2108,7 @@ maps to an AI Catalog where each plugin is an entry:
     {
       "identifier": "urn:claude-plugin:aikido:security",
       "displayName": "aikido",
-      "type": "application/vnd.anthropic.claude-plugin+json",
+      "mediaType": "application/vnd.anthropic.claude-plugin+json",
       "url": "https://github.com/AikidoSec/aikido-claude-plugin.git",
       "description": "Aikido Security scanning — SAST, secrets, and IaC vulnerability detection.",
       "tags": ["security"],
@@ -2146,7 +2142,7 @@ contains multiple artifact types:
 {
   "identifier": "urn:claude-plugin:anthropic:example-plugin",
   "displayName": "example-plugin",
-  "type": "application/ai-catalog+json",
+  "mediaType": "application/ai-catalog+json",
   "description": "Comprehensive plugin with commands, agents, skills, and MCP servers",
   "tags": ["development"],
   "publisher": {
@@ -2159,13 +2155,13 @@ contains multiple artifact types:
       {
         "identifier": "urn:claude-plugin:anthropic:example-plugin:mcp",
         "displayName": "Example Plugin MCP Server",
-        "type": "application/mcp-server+json",
+        "mediaType": "application/mcp-server-card+json",
         "url": "https://github.com/anthropics/claude-plugins-official/blob/main/plugins/example-plugin/server-card.json"
       },
       {
         "identifier": "urn:claude-plugin:anthropic:example-plugin:skills",
         "displayName": "Example Plugin Skills",
-        "type": "application/ai-skills+zip",
+        "mediaType": "application/agentskill+zip",
         "url": "https://github.com/anthropics/claude-plugins-official/tree/main/plugins/example-plugin/skills.zip"
       }
     ]

--- a/src/discover/hf_spaces.py
+++ b/src/discover/hf_spaces.py
@@ -111,15 +111,15 @@ def hf_space_mcp_url(space_id: str, *, app_url: str | None = None) -> str:
 
 
 def hf_space_identifier(space_id: str) -> str:
-    return f"urn:ai:hf.co:space:{space_id.replace('/', ':')}"
+    return f"urn:ai:huggingface.co:space:{space_id.replace('/', ':')}"
 
 
 def hf_space_skill_identifier(space_id: str) -> str:
-    return f"urn:ai:hf.co:skill:space:{space_id.replace('/', ':')}"
+    return f"urn:ai:huggingface.co:skill:space:{space_id.replace('/', ':')}"
 
 
 def hf_space_mcp_identifier(space_id: str) -> str:
-    return f"urn:ai:hf.co:mcp:space:{space_id.replace('/', ':')}"
+    return f"urn:ai:huggingface.co:mcp:space:{space_id.replace('/', ':')}"
 
 
 def split_space_id(space_id: str) -> tuple[str, str]:

--- a/src/discover/server.py
+++ b/src/discover/server.py
@@ -153,7 +153,7 @@ def _spaces_registry_search_url(base_url: str) -> str:
 
 def _spaces_registry_referral(base_url: str) -> CatalogEntry:
     return CatalogEntry(
-        identifier="urn:ai:hf.co:registry:spaces",
+        identifier="urn:ai:huggingface.co:registry:spaces",
         displayName="Hugging Face Spaces Registry",
         type=AI_REGISTRY_MEDIA_TYPE,
         url=_spaces_registry_search_url(base_url),
@@ -168,7 +168,7 @@ def _spaces_registry_referral(base_url: str) -> CatalogEntry:
 
 def _registry_catalog_entry(base_url: str) -> CatalogEntry:
     return CatalogEntry(
-        identifier="urn:ai:hf.co:registry:discover",
+        identifier="urn:ai:huggingface.co:registry:discover",
         displayName="Hugging Face Discover Registry",
         type=AI_REGISTRY_MEDIA_TYPE,
         url=f"{base_url.rstrip('/')}/search",
@@ -183,7 +183,7 @@ def _catalog_payload(base_url: str) -> dict[str, object]:
         "specVersion": "1.0",
         "host": {
             "displayName": "Hugging Face Discover",
-            "identifier": "hf.co",
+            "identifier": "huggingface.co",
             "documentationUrl": "https://github.com/huggingface/hf-discover",
         },
         "entries": [

--- a/tests/test_hf_spaces.py
+++ b/tests/test_hf_spaces.py
@@ -240,7 +240,7 @@ class RecordingSearch:
         )
         return [
             SearchResult(
-                identifier="urn:ai:hf.co:skill:space:alice:image-tool",
+                identifier="urn:ai:huggingface.co:skill:space:alice:image-tool",
                 displayName="Image Tool",
                 type=media_type,
                 url=url,
@@ -327,7 +327,7 @@ def test_space_to_search_result_defaults_to_skill_wrapper() -> None:
     space = Space(id="alice/cool.space", tags=["image-to-image"], runtime=Runtime(stage="RUNNING"))
     result = space_to_search_result(cast("SpaceSearchResultLike", space))
 
-    assert result.identifier == "urn:ai:hf.co:skill:space:alice:cool.space"
+    assert result.identifier == "urn:ai:huggingface.co:skill:space:alice:cool.space"
     assert result.displayName == "Image Tool"
     assert result.type == AI_SKILL_MEDIA_TYPE
     assert result.url == (f"{SPACES_URL_PREFIX}/skills/huggingface/alice/cool.space/SKILL.md")
@@ -362,7 +362,7 @@ def test_space_to_search_result_can_return_generic_space_descriptor() -> None:
     space = Space(id="alice/cool.space")
     result = space_to_search_result(cast("SpaceSearchResultLike", space), kind="space")
 
-    assert result.identifier == "urn:ai:hf.co:space:alice:cool.space"
+    assert result.identifier == "urn:ai:huggingface.co:space:alice:cool.space"
     assert result.type == HF_SPACE_MEDIA_TYPE
     assert result.url is None
     assert result.data is not None
@@ -837,7 +837,7 @@ def test_discover_search_applies_scalar_publisher_and_metadata_filters() -> None
                 text="tool server",
                 filter={
                     "type": MCP_SERVER_MEDIA_TYPE,
-                    "publisher": "hf.co",
+                    "publisher": "huggingface.co",
                     "metadata.sourceType": "huggingface-space",
                 },
             ),
@@ -854,7 +854,7 @@ def test_discover_search_filters_by_capability_array_values() -> None:
     def search_spaces(query: str, **kwargs: object) -> list[SearchResult]:
         return [
             SearchResult(
-                identifier="urn:ai:hf.co:mcp:space:alice:image-tool",
+                identifier="urn:ai:huggingface.co:mcp:space:alice:image-tool",
                 displayName="Image Tool",
                 type=MCP_SERVER_MEDIA_TYPE,
                 url="https://example.com/server.json",
@@ -893,7 +893,7 @@ def test_discover_search_returns_spaces_referral_when_requested() -> None:
 
     assert response.results == []
     assert [referral.identifier for referral in response.referrals] == [
-        "urn:ai:hf.co:registry:spaces"
+        "urn:ai:huggingface.co:registry:spaces"
     ]
     assert (
         response.referrals[0].url
@@ -938,14 +938,14 @@ def test_primary_server_exposes_v5_ai_catalog_well_known_document() -> None:
     assert response.headers["content-type"].startswith("application/ai-catalog+json")
     body = response.json()
     assert body["specVersion"] == "1.0"
-    assert body["host"]["identifier"] == "hf.co"
+    assert body["host"]["identifier"] == "huggingface.co"
 
     entries = body["entries"]
     assert all("type" in entry for entry in entries)
     assert all("mediaType" not in entry for entry in entries)
     assert entries == [
         {
-            "identifier": "urn:ai:hf.co:registry:discover",
+            "identifier": "urn:ai:huggingface.co:registry:discover",
             "displayName": "Hugging Face Discover Registry",
             "type": "application/ai-registry+json",
             "url": "http://testserver/search",
@@ -954,7 +954,7 @@ def test_primary_server_exposes_v5_ai_catalog_well_known_document() -> None:
             "metadata": {"path": "/search"},
         },
         {
-            "identifier": "urn:ai:hf.co:registry:spaces",
+            "identifier": "urn:ai:huggingface.co:registry:spaces",
             "displayName": "Hugging Face Spaces Registry",
             "type": "application/ai-registry+json",
             "url": "http://testserver/registries/huggingface/spaces/search",


### PR DESCRIPTION
## Summary
- emit `huggingface.co` as the ARD host/publisher domain instead of `hf.co`
- update generated Hugging Face Space, skill, MCP, and registry URNs to `urn:ai:huggingface.co:...`
- refresh the vendored `Agent-Card/ai-catalog` snapshot and ignore the local ai-catalog reference checkout

## Validation
- `uv run pytest tests/test_hf_spaces.py tests/test_models.py`
- `uv run ruff check src tests`
- `uv run ty check`
