### PR TITLE
Added support for new urn:air with backwards compat for urn:ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,11 @@ Space-specific.
 
 The registry uses the ARD v0.5 search envelope: artifact type constraints are
 expressed as `query.filter.type`, response entries use the catalog `type` field, and
-Hugging Face entries use domain-anchored `urn:ai:huggingface.co:...` identifiers. Catalog entry
-models enforce the v0.5 strict value-or-reference rule, domain-anchored `urn:ai:<fqdn>:...`
-identifiers, and integer 0-100 relevance scores.
+Hugging Face entries use domain-anchored `urn:air:huggingface.co:...` identifiers. Catalog entry
+models enforce the v0.5 strict value-or-reference rule, domain-anchored `urn:air:<fqdn>:...`
+identifiers, and integer 0-100 relevance scores. The legacy `urn:ai:` prefix from
+earlier drafts is still accepted during the transition and emits a `DeprecationWarning`
+when encountered; new publishers MUST use `urn:air:`.
 
 Structured filters use the ARD v0.5 field-path semantics for exact matching after
 retrieval: scalar filter values are treated like single-item arrays, values within one
@@ -141,7 +143,7 @@ is derived from the entry identifier's publisher domain.
 The primary server exposes `GET /.well-known/ai-catalog.json` as an ARD discovery
 document. It advertises the primary Hugging Face Discover registry and the nested
 Spaces registry as `application/ai-registry+json` entries using v0.5 `type` fields,
-domain-anchored `urn:ai:huggingface.co:...` identifiers, and registry service base URLs. Clients
+domain-anchored `urn:air:huggingface.co:...` identifiers, and registry service base URLs. Clients
 append `/search` to those base URLs for Search requests.
 
 By default, advertised registry base URLs, generated Space skill URLs, and generated MCP

--- a/spec/ard.md
+++ b/spec/ard.md
@@ -80,7 +80,7 @@ A manifest file hosted at /.well-known/ai-catalog.json lists the available artif
   },
   "entries": [
     {
-      "identifier": "urn:ai:acme.com:agent:assistant",
+      "identifier": "urn:air:acme.com:agent:assistant",
       "displayName": "Corporate Assistant (A2A)",
       "type": "application/a2a-agent-card+json",
       "url": "https://api.acme.com/agents/assistant.json",
@@ -91,7 +91,7 @@ A manifest file hosted at /.well-known/ai-catalog.json lists the available artif
       ]
     },
     {
-      "identifier": "urn:ai:acme.com:server:weather",
+      "identifier": "urn:air:acme.com:server:weather",
       "displayName": "Weather Data Node",
       "type": "application/mcp-server+json",
       "url": "https://api.acme.com/mcp/weather.json",
@@ -103,7 +103,7 @@ A manifest file hosted at /.well-known/ai-catalog.json lists the available artif
       ]
     },
     {
-      "identifier": "urn:ai:acme.com:plugin:finance-suite",
+      "identifier": "urn:air:acme.com:plugin:finance-suite",
       "displayName": "Finance Tool Bundle",
       "type": "application/ai-catalog+json",
       "description": "A static nested bundle containing an A2A agent and its required market dataset.",
@@ -112,13 +112,13 @@ A manifest file hosted at /.well-known/ai-catalog.json lists the available artif
         "specVersion": "1.0",
         "entries": [
           {
-            "identifier": "urn:ai:acme.com:finance:a2a",
+            "identifier": "urn:air:acme.com:finance:a2a",
             "displayName": "Finance Trading Agent",
             "type": "application/a2a-agent-card+json",
             "url": "https://api.acme.com/agents/finance-trader.json"
           },
           {
-            "identifier": "urn:ai:acme.com:market:2026",
+            "identifier": "urn:air:acme.com:market:2026",
             "displayName": "Market Dataset 2026",
             "type": "application/parquet",
             "url": "https://data.acme.com/market-2026.parquet"
@@ -127,7 +127,7 @@ A manifest file hosted at /.well-known/ai-catalog.json lists the available artif
       }
     },
     {
-      "identifier": "urn:ai:acme.com:registry:global",
+      "identifier": "urn:air:acme.com:registry:global",
       "displayName": "Acme Global Agent Registry",
       "type": "application/ai-registry+json",
       "url": "https://registry.acme.com/api/v1/",
@@ -151,7 +151,7 @@ A manifest file hosted at /.well-known/ai-catalog.json lists the available artif
       }
     },
     {
-      "identifier": "urn:ai:acme.com:catalog:engineering",
+      "identifier": "urn:air:acme.com:catalog:engineering",
       "displayName": "Engineering Department Catalogs",
       "type": "application/ai-catalog+json",
       "url": "https://acme.com/catalogs/engineering.json",
@@ -167,7 +167,7 @@ Each object in the entries array MUST contain:
 
 | Field | Type | Description |
 | :---- | :---- | :---- |
-| identifier | String | Globally unique logical identifier for discovery. MUST use a domain-anchored URN namespace format (urn:ai:\<publisher\>:\<namespace\>:\<agent-name\>) where \<publisher\> is a verifiable domain name. This guarantees cross-network uniqueness, nomenclature stability, and decentralized trust binding. See [§4.2.1](#421-agent-identifier-identifier-format-and-rationale) for detailed format specifications and architectural rationale. |
+| identifier | String | Globally unique logical identifier for discovery. MUST use a domain-anchored URN namespace format (urn:air:\<publisher\>:\<namespace\>:\<agent-name\>) where \<publisher\> is a verifiable domain name. This guarantees cross-network uniqueness, nomenclature stability, and decentralized trust binding. See [§4.2.1](#421-agent-identifier-identifier-format-and-rationale) for detailed format specifications and architectural rationale. |
 | displayName | String | Human-readable name. |
 | type | String | Type of the AI artifact. |
 
@@ -196,7 +196,7 @@ Optional fields:
 The identifier field serves as the primary logical handle for an agent or capability across federated discovery networks. It MUST follow a standardized, domain-anchored URN format complying with IETF RFC 8141:
 
 ```
-urn:ai:<publisher>:<namespace>:<agent-name>
+urn:air:<publisher>:<namespace>:<agent-name>
 ```
 
 #### Format Structure
@@ -235,7 +235,7 @@ An agent hosted on Hugging Face Spaces (MCP), published in a manifest:
   "host": { "displayName": "Alice's AI Tools" },
   "entries": [
     {
-      "identifier": "urn:ai:hf.co:alice-dev:weather-agent",
+      "identifier": "urn:air:hf.co:alice-dev:weather-agent",
       "displayName": "Weather Agent",
       "type": "application/mcp-server+json",
       "inline": {
@@ -266,7 +266,7 @@ A skill hosted on GitHub, published in a manifest:
   "host": { "displayName": "Alice's AI Tools" },
   "entries": [
     {
-      "identifier": "urn:ai:github.com:alice-dev:pptx-creator",
+      "identifier": "urn:air:github.com:alice-dev:pptx-creator",
       "displayName": "pptx-creator",
       "type": "application/ai-skill",
       "url": "https://github.com/alice-dev/pptx-creator",
@@ -284,13 +284,13 @@ Discovery via GitHub Pages (combining the above):
   "host": { "displayName": "Alice's AI Tools" },
   "entries": [
     {
-      "identifier": "urn:ai:hf.co:alice-dev:weather-agent",
+      "identifier": "urn:air:hf.co:alice-dev:weather-agent",
       "displayName": "Weather Agent",
       "type": "application/mcp-server+json",
       "url": "https://alice-dev.github.io/weather-agent/entry.json"
     },
     {
-      "identifier": "urn:ai:github.com:alice-dev:pptx-creator",
+      "identifier": "urn:air:github.com:alice-dev:pptx-creator",
       "displayName": "pptx-creator",
       "type": "application/ai-skill+md",
       "url": "https://github.com/alice-dev/pptx-creator"
@@ -312,7 +312,7 @@ Using trustManifest for compliance, published in a manifest.
   },
   "entries": [
     {
-      "identifier": "urn:ai:acme.com:travel:concierge",
+      "identifier": "urn:air:acme.com:travel:concierge",
       "displayName": "Travel Concierge",
       "type": "application/a2a-agent-card+json",
       "url": "https://api.acme.com/travel/concierge.json",
@@ -480,7 +480,7 @@ The response returns standard catalog entries with additional relevance scores, 
 {
   "results": [
     {
-      "identifier": "urn:ai:acme.com:agent:assistant",
+      "identifier": "urn:air:acme.com:agent:assistant",
       "displayName": "Corporate Assistant (A2A)",
       "type": "application/a2a-agent-card+json",
       "url": "https://api.acme.com/agents/assistant.json",
@@ -488,7 +488,7 @@ The response returns standard catalog entries with additional relevance scores, 
       "source": "https://registry.acme.com/api/v1/"
     },
     {
-      "identifier": "urn:ai:example.com:weather-server",
+      "identifier": "urn:air:example.com:weather-server",
       "displayName": "Global Weather Service",
       "type": "application/mcp-server+json",
       "url": "https://weather.example.com/mcp",
@@ -499,7 +499,7 @@ The response returns standard catalog entries with additional relevance scores, 
   ],
   "referrals": [
     {
-      "identifier": "urn:ai:nlweb.ai:registry:public",
+      "identifier": "urn:air:nlweb.ai:registry:public",
       "displayName": "Public ARD",
       "type": "application/ai-registry",
       "url": "https://finder.nlweb.ai/search"
@@ -633,7 +633,7 @@ This gives the client full control over the federation topology without requirin
 {
   "results": [
     {
-      "identifier": "urn:ai:acme.com:agent:expense",
+      "identifier": "urn:air:acme.com:agent:expense",
       "displayName": "Corporate Expenses",
       "type": "application/a2a-agent-card+json",
       "url": "https://internal.corp/agents/expense.json",
@@ -643,13 +643,13 @@ This gives the client full control over the federation topology without requirin
   ],
   "referrals": [
     {
-      "identifier": "urn:ai:blweb.ai:registry:public",
+      "identifier": "urn:air:blweb.ai:registry:public",
       "displayName": "Public ARD",
       "type": "application/ai-registry",
       "url": "https://finder.nlweb.ai/search"
     },
     {
-      "identifier": "urn:ai:example.com:registry:travel",
+      "identifier": "urn:air:example.com:registry:travel",
       "displayName": "Travel ARD",
       "mediaType": "application/ai-registry",
       "url": "https://travel.finder.example/search"
@@ -697,10 +697,10 @@ Logical AND is used across different parameters; OR is used within a single para
 
 Restricting the discovery identifier to this specific URN format, rather than allowing arbitrary URIs (such as https://... or spiffe://...), provides fundamental architectural benefits for federated agent discovery:
 
-1. **Nomenclature Stability (Immutable Noun vs. Mutable Location)**: Arbitrary URIs, particularly HTTP URLs, conflate the *logical identity* of a capability with its *physical network location*. If an enterprise migrates workloads across cloud providers, restructures its API gateway, or alters its deployment clusters, an HTTP URL breaks. The urn:ai: identifier acts as an abstract, permanent contract (the "noun"). Physical distribution and transport bindings are decoupled into the url or data fields, allowing underlying infrastructure to evolve without breaking client discovery, indexing, or orchestration code.  
-2. **Strict Separation of Concerns**: Federated search registries require a clean, stable primary key to index capabilities efficiently across global networks. Conversely, zero-trust execution runtimes require dynamic, verifiable cryptographic tokens (SPIFFE IDs, DIDs, X.509 certificates) to authenticate workloads. Forcing a single URI to serve both roles creates an architectural bottleneck. The urn:ai: format cleanly decouples the searchable discovery handle from the security principal, allowing the discovery index and the security mesh to operate independently.  
-3. **Decentralized Trust and Authority Binding**: In a globally federated open discovery network, search registries must prevent malicious actors from claiming namespaces they do not own (e.g., an untrusted publisher claiming urn:ai:google.com:tax-agent). Mandating that \<publisher\> be a valid FQDN establishes an immediate, verifiable authority anchor. Registries and orchestrators programmatically extract the domain from the URN (google.com) and cross-reference it with the cryptographic claim in trustManifest.identity. If the workload cannot produce a valid cryptographic attestation (e.g., mTLS certificate or SPIFFE SVID) issued by google.com, the capability is rejected. This ensures decentralized, zero-trust verification without requiring a centralized naming committee.  
-4. **Search and Discovery Ergonomics (The @ Resolution Pattern)**: Users and LLMs require intuitive, semantic handles for capabilities (e.g., Assistant@Acme). The structured hierarchy of urn:ai:\<publisher\>:\<namespace\>:\<agent-name\> allows search engines and federated registries to parse components deterministically. Registries can easily match natural language queries to the publisher domain (Acme) and the terminal short name (Assistant), enabling high-performance semantic filtering, aggregation, and conflict resolution (e.g., displaying Assistant with a verified Acme shield).  
+1. **Nomenclature Stability (Immutable Noun vs. Mutable Location)**: Arbitrary URIs, particularly HTTP URLs, conflate the *logical identity* of a capability with its *physical network location*. If an enterprise migrates workloads across cloud providers, restructures its API gateway, or alters its deployment clusters, an HTTP URL breaks. The urn:air: identifier acts as an abstract, permanent contract (the "noun"). Physical distribution and transport bindings are decoupled into the url or data fields, allowing underlying infrastructure to evolve without breaking client discovery, indexing, or orchestration code.  
+2. **Strict Separation of Concerns**: Federated search registries require a clean, stable primary key to index capabilities efficiently across global networks. Conversely, zero-trust execution runtimes require dynamic, verifiable cryptographic tokens (SPIFFE IDs, DIDs, X.509 certificates) to authenticate workloads. Forcing a single URI to serve both roles creates an architectural bottleneck. The urn:air: format cleanly decouples the searchable discovery handle from the security principal, allowing the discovery index and the security mesh to operate independently.  
+3. **Decentralized Trust and Authority Binding**: In a globally federated open discovery network, search registries must prevent malicious actors from claiming namespaces they do not own (e.g., an untrusted publisher claiming urn:air:google.com:tax-agent). Mandating that \<publisher\> be a valid FQDN establishes an immediate, verifiable authority anchor. Registries and orchestrators programmatically extract the domain from the URN (google.com) and cross-reference it with the cryptographic claim in trustManifest.identity. If the workload cannot produce a valid cryptographic attestation (e.g., mTLS certificate or SPIFFE SVID) issued by google.com, the capability is rejected. This ensures decentralized, zero-trust verification without requiring a centralized naming committee.  
+4. **Search and Discovery Ergonomics (The @ Resolution Pattern)**: Users and LLMs require intuitive, semantic handles for capabilities (e.g., Assistant@Acme). The structured hierarchy of urn:air:\<publisher\>:\<namespace\>:\<agent-name\> allows search engines and federated registries to parse components deterministically. Registries can easily match natural language queries to the publisher domain (Acme) and the terminal short name (Assistant), enabling high-performance semantic filtering, aggregation, and conflict resolution (e.g., displaying Assistant with a verified Acme shield).  
 5. **Cross-Network Uniqueness and Federation Scalability**: Domain-anchored URNs guarantee global uniqueness across disparate federated registries without requiring centralized registration databases. Because domain names are already globally unique via the DNS root, anchoring the URN to a domain eliminates collision risks when merging catalogs from multiple upstream registries in auto or referrals federation modes.
 
 ---
@@ -726,7 +726,7 @@ The JSON representation of the capability manifest hosted at `/.well-known/ai-ca
 
 * **Authoritative Schema File**: [`spec/schemas/ai-catalog.schema.json`](schemas/ai-catalog.schema.json)
 * **Key Validation Enforcements**:
-  * Pattern matching URN compliance rules for the logical `identifier` format (`^urn:ai:...`).
+  * Pattern matching URN compliance rules for the logical `identifier` format (`^urn:air:...`).
   * Strict Value-or-Reference exclusion logic (`oneOf` matching either `url` or `data`, preventing duplicate definitions).
   * Struct checking for SPIFFE/DID compliance in `trustManifest` and `attestations` objects.
 

--- a/src/discover/challenge.py
+++ b/src/discover/challenge.py
@@ -36,7 +36,7 @@ def _score(entry: SearchResult, query: str, index: int) -> int:
 
 def _skill_result(base_url: str, name: str, description: str, score: int) -> SearchResult:
     return SearchResult(
-        identifier=f"urn:ai:{CHALLENGE_PUBLISHER}:challenge:skill:{name}",
+        identifier=f"urn:air:{CHALLENGE_PUBLISHER}:challenge:skill:{name}",
         displayName=name,
         type=AI_SKILL_MEDIA_TYPE,
         url=f"{base_url}/artifacts/skills/{name}/SKILL.md",
@@ -51,7 +51,7 @@ def _skill_result(base_url: str, name: str, description: str, score: int) -> Sea
 
 def _mcp_result(base_url: str, name: str, description: str, score: int) -> SearchResult:
     return SearchResult(
-        identifier=f"urn:ai:{CHALLENGE_PUBLISHER}:challenge:mcp:{name}",
+        identifier=f"urn:air:{CHALLENGE_PUBLISHER}:challenge:mcp:{name}",
         displayName=f"{name} MCP Server",
         type=MCP_SERVER_MEDIA_TYPE,
         data={
@@ -77,7 +77,7 @@ def _mcp_result(base_url: str, name: str, description: str, score: int) -> Searc
 
 def _a2a_result(name: str, description: str, score: int) -> SearchResult:
     return SearchResult(
-        identifier=f"urn:ai:{CHALLENGE_PUBLISHER}:challenge:a2a:{name}",
+        identifier=f"urn:air:{CHALLENGE_PUBLISHER}:challenge:a2a:{name}",
         displayName=f"{name} A2A Agent",
         type=A2A_AGENT_MEDIA_TYPE,
         data={
@@ -97,7 +97,7 @@ def _a2a_result(name: str, description: str, score: int) -> SearchResult:
 
 def _catalog_result(base_url: str, score: int) -> SearchResult:
     return SearchResult(
-        identifier=f"urn:ai:{CHALLENGE_PUBLISHER}:challenge:catalog:bundle",
+        identifier=f"urn:air:{CHALLENGE_PUBLISHER}:challenge:catalog:bundle",
         displayName="Challenge Bundle Catalog",
         type=AI_CATALOG_MEDIA_TYPE,
         data={
@@ -105,13 +105,13 @@ def _catalog_result(base_url: str, score: int) -> SearchResult:
             "host": {"displayName": "Challenge Bundle"},
             "entries": [
                 {
-                    "identifier": f"urn:ai:{CHALLENGE_PUBLISHER}:challenge:bundle:skill",
+                    "identifier": f"urn:air:{CHALLENGE_PUBLISHER}:challenge:bundle:skill",
                     "displayName": "Bundled Skill",
                     "type": AI_SKILL_MEDIA_TYPE,
                     "url": f"{base_url}/artifacts/skills/bundled-skill/SKILL.md",
                 },
                 {
-                    "identifier": f"urn:ai:{CHALLENGE_PUBLISHER}:challenge:bundle:mcp",
+                    "identifier": f"urn:air:{CHALLENGE_PUBLISHER}:challenge:bundle:mcp",
                     "displayName": "Bundled MCP",
                     "type": MCP_SERVER_MEDIA_TYPE,
                     "data": {"name": "bundled-mcp", "transport": "stdio", "command": "echo"},
@@ -135,7 +135,7 @@ def _registry_result(
     score: int,
 ) -> SearchResult:
     return SearchResult(
-        identifier=f"urn:ai:{CHALLENGE_PUBLISHER}:challenge:registry:{name}",
+        identifier=f"urn:air:{CHALLENGE_PUBLISHER}:challenge:registry:{name}",
         displayName=f"{name.title()} Challenge Registry",
         type=AI_REGISTRY_MEDIA_TYPE,
         url=f"{base_url}{path}",
@@ -150,7 +150,7 @@ def _registry_result(
 
 def _referral(base_url: str, name: str, path: str, description: str) -> CatalogEntry:
     return CatalogEntry(
-        identifier=f"urn:ai:{CHALLENGE_PUBLISHER}:challenge:registry:{name}",
+        identifier=f"urn:air:{CHALLENGE_PUBLISHER}:challenge:registry:{name}",
         displayName=f"{name.title()} Challenge Registry",
         type=AI_REGISTRY_MEDIA_TYPE,
         url=f"{base_url}{path}",

--- a/src/discover/cli.py
+++ b/src/discover/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError, version
 from typing import Annotated, Literal
@@ -256,6 +257,8 @@ def parse_navigate_args(args: list[str]) -> tuple[str, str]:
 @app.callback()
 def main(version_requested: VersionOpt = False) -> None:
     """ARD registry adapters."""
+    # DEPRECATED(urn:ai): surface legacy-prefix warnings on stderr.
+    warnings.filterwarnings("default", category=DeprecationWarning, module="discover.*")
     if version_requested:
         _print_version()
         raise typer.Exit

--- a/src/discover/filters.py
+++ b/src/discover/filters.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from discover.models import SearchResult
 
-URN_AI_PUBLISHER_PARTS = 3
+URN_AIR_PUBLISHER_PARTS = 3
 TYPE_FILTER_ALIASES = {
     "application/mcp-server+json": "application/mcp-server-card+json",
 }
@@ -13,9 +13,12 @@ TYPE_FILTER_ALIASES = {
 
 def publisher_from_identifier(identifier: str) -> str | None:
     parts = identifier.split(":")
-    if len(parts) >= URN_AI_PUBLISHER_PARTS and parts[0] == "urn" and parts[1] == "ai":
-        return parts[2]
-    return None
+    if len(parts) < URN_AIR_PUBLISHER_PARTS or parts[0] != "urn":
+        return None
+    # DEPRECATED(urn:ai): accept legacy "ai" namespace; remove with urn:ai support.
+    if parts[1] not in {"air", "ai"}:
+        return None
+    return parts[2]
 
 
 def entry_values_at_path(value: Any, path: list[str]) -> list[Any]:

--- a/src/discover/hf_skills.py
+++ b/src/discover/hf_skills.py
@@ -128,7 +128,7 @@ def _skill_key(hit: dict[str, Any]) -> str:
 
 
 def _skill_identifier(skill: str) -> str:
-    return f"urn:ai:github.com:huggingface:skills:{skill.replace('/', ':')}"
+    return f"urn:air:github.com:huggingface:skills:{skill.replace('/', ':')}"
 
 
 def _skill_directory_path(value: str) -> str:

--- a/src/discover/hf_spaces.py
+++ b/src/discover/hf_spaces.py
@@ -111,15 +111,15 @@ def hf_space_mcp_url(space_id: str, *, app_url: str | None = None) -> str:
 
 
 def hf_space_identifier(space_id: str) -> str:
-    return f"urn:ai:huggingface.co:space:{space_id.replace('/', ':')}"
+    return f"urn:air:huggingface.co:space:{space_id.replace('/', ':')}"
 
 
 def hf_space_skill_identifier(space_id: str) -> str:
-    return f"urn:ai:huggingface.co:skill:space:{space_id.replace('/', ':')}"
+    return f"urn:air:huggingface.co:skill:space:{space_id.replace('/', ':')}"
 
 
 def hf_space_mcp_identifier(space_id: str) -> str:
-    return f"urn:ai:huggingface.co:mcp:space:{space_id.replace('/', ':')}"
+    return f"urn:air:huggingface.co:mcp:space:{space_id.replace('/', ':')}"
 
 
 def split_space_id(space_id: str) -> tuple[str, str]:

--- a/src/discover/models.py
+++ b/src/discover/models.py
@@ -1,18 +1,21 @@
 from __future__ import annotations
 
 import re
+import warnings
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 FederationMode = Literal["auto", "referrals", "none"]
-URN_AI_IDENTIFIER_RE = re.compile(
-    r"^urn:ai:"
+_URN_AIR_BODY = (
     r"(?P<publisher>(?=.{1,253}:)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+"
     r"[A-Za-z]{2,63})"
     r":[A-Za-z0-9._~!$&'()*+,;=@%-]+"
     r"(?::[A-Za-z0-9._~!$&'()*+,;=@%-]+)*$"
 )
+URN_AIR_IDENTIFIER_RE = re.compile(r"^urn:air:" + _URN_AIR_BODY)
+# DEPRECATED(urn:ai): legacy ARD prefix accepted during transition; remove with urn:ai support.
+URN_AI_LEGACY_IDENTIFIER_RE = re.compile(r"^urn:ai:" + _URN_AIR_BODY)
 
 
 class CatalogEntry(BaseModel):
@@ -37,12 +40,23 @@ class CatalogEntry(BaseModel):
     @field_validator("identifier")
     @classmethod
     def validate_identifier(cls, value: str) -> str:
-        if URN_AI_IDENTIFIER_RE.fullmatch(value) is None:
-            raise ValueError(
-                "identifier must use domain-anchored ARD URN format "
-                "urn:ai:<publisher-fqdn>:<namespace-or-name>[:<agent-name>...]"
+        if URN_AIR_IDENTIFIER_RE.fullmatch(value) is not None:
+            return value
+        # DEPRECATED(urn:ai): accept legacy prefix and warn; remove with urn:ai support.
+        if URN_AI_LEGACY_IDENTIFIER_RE.fullmatch(value) is not None:
+            warnings.warn(
+                f"ARD identifier {value!r} uses the deprecated 'urn:ai:' prefix; "
+                "the spec has renamed it to 'urn:air:'. Update publishers before "
+                "'urn:ai:' support is removed.",
+                DeprecationWarning,
+                stacklevel=2,
             )
-        return value
+            return value
+        raise ValueError(
+            "identifier must use domain-anchored ARD URN format "
+            "urn:air:<publisher-fqdn>:<namespace-or-name>[:<agent-name>...] "
+            "(legacy 'urn:ai:' is accepted with a deprecation warning during transition)"
+        )
 
     @model_validator(mode="after")
     def validate_value_or_reference(self) -> CatalogEntry:

--- a/src/discover/navigation.py
+++ b/src/discover/navigation.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import json
+import warnings
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.error import HTTPError, URLError
 from urllib.parse import urljoin, urlparse
 from urllib.request import Request as UrlRequest
@@ -14,10 +15,37 @@ from discover.filters import apply_entry_filters
 from discover.hf_spaces import AI_SKILL_MEDIA_TYPE, HF_SPACE_MEDIA_TYPE, MCP_SERVER_MEDIA_TYPE
 from discover.models import CatalogEntry, SearchQuery, SearchRequest, SearchResponse, SearchResult
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
 AI_CATALOG_MEDIA_TYPES = {"application/ai-catalog+json", "application/ai-catalog"}
 AI_REGISTRY_MEDIA_TYPES = {"application/ai-registry+json", "application/ai-registry"}
 NavigationStatus = Literal["ok", "error", "skipped"]
 MAX_RESPONSE_BYTES = 2_000_000
+
+# DEPRECATED(urn:ai): per-traversal dedup; remove with urn:ai support.
+
+
+def _warn_legacy_urns(
+    identifiers: Iterable[str],
+    *,
+    source: str,
+    seen: set[tuple[str, str]],
+) -> None:
+    # DEPRECATED(urn:ai): remove with urn:ai support.
+    for identifier in identifiers:
+        if not identifier.startswith("urn:ai:"):
+            continue
+        key = (identifier, source)
+        if key in seen:
+            continue
+        seen.add(key)
+        warnings.warn(
+            f"ARD identifier {identifier!r} from {source} uses the deprecated "
+            "'urn:ai:' prefix; the spec has renamed it to 'urn:air:'.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
 
 @dataclass(frozen=True)
@@ -208,6 +236,8 @@ def navigate(  # noqa: C901, PLR0913, PLR0915 - traversal orchestration is clear
     catalog_queue: list[tuple[str, int]] = [(well_known_catalog_url(url), 0)]
     visited_catalogs: set[str] = set()
     visited_registries: set[str] = set()
+    # DEPRECATED(urn:ai): per-traversal legacy-prefix warning dedup; remove with urn:ai support.
+    legacy_urn_seen: set[tuple[str, str]] = set()
 
     def visit_registry(registry_url: str) -> None:
         search_url = registry_search_url(registry_url)
@@ -229,6 +259,11 @@ def navigate(  # noqa: C901, PLR0913, PLR0915 - traversal orchestration is clear
             )
             return
         discovered.append(DiscoveredResource("registry", search_url))
+        _warn_legacy_urns(
+            (entry.identifier for entry in (*response.results, *response.referrals)),
+            source=search_url,
+            seen=legacy_urn_seen,
+        )
         results.extend(_with_source(result, search_url) for result in response.results)
         referrals.extend(response.referrals)
         if follow_referrals:
@@ -256,6 +291,11 @@ def navigate(  # noqa: C901, PLR0913, PLR0915 - traversal orchestration is clear
             )
             continue
         discovered.append(DiscoveredResource("catalog", catalog_url))
+        _warn_legacy_urns(
+            (entry.identifier for entry in entries),
+            source=catalog_url,
+            seen=legacy_urn_seen,
+        )
         for entry in entries:
             if entry.type in AI_REGISTRY_MEDIA_TYPES and entry.url is not None:
                 visit_registry(entry.url)

--- a/src/discover/server.py
+++ b/src/discover/server.py
@@ -164,7 +164,7 @@ def _spaces_registry_base_url(base_url: str) -> str:
 
 def _spaces_registry_referral(base_url: str) -> CatalogEntry:
     return CatalogEntry(
-        identifier="urn:ai:huggingface.co:registry:spaces",
+        identifier="urn:air:huggingface.co:registry:spaces",
         displayName="Hugging Face Spaces Registry",
         type=AI_REGISTRY_MEDIA_TYPE,
         url=_spaces_registry_search_url(base_url),
@@ -178,7 +178,7 @@ def _spaces_registry_referral(base_url: str) -> CatalogEntry:
 
 def _spaces_registry_catalog_entry(base_url: str) -> CatalogEntry:
     return CatalogEntry(
-        identifier="urn:ai:huggingface.co:registry:spaces",
+        identifier="urn:air:huggingface.co:registry:spaces",
         displayName="Hugging Face Spaces Registry",
         type=AI_REGISTRY_MEDIA_TYPE,
         url=_spaces_registry_base_url(base_url),
@@ -192,7 +192,7 @@ def _spaces_registry_catalog_entry(base_url: str) -> CatalogEntry:
 
 def _registry_catalog_entry(base_url: str) -> CatalogEntry:
     return CatalogEntry(
-        identifier="urn:ai:huggingface.co:registry:discover",
+        identifier="urn:air:huggingface.co:registry:discover",
         displayName="Hugging Face Discover Registry",
         type=AI_REGISTRY_MEDIA_TYPE,
         url=base_url.rstrip("/"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -125,7 +125,7 @@ def test_registry_response_error_message_explains_missing_v5_type_field() -> Non
             {
                 "results": [
                     {
-                        "identifier": "urn:ai:example.com:skill",
+                        "identifier": "urn:air:example.com:skill",
                         "displayName": "Example Skill",
                         "url": "https://example.com/SKILL.md",
                         "score": 91,
@@ -151,7 +151,7 @@ def test_registry_response_error_message_summarizes_many_missing_fields() -> Non
             {
                 "results": [
                     {
-                        "identifier": f"urn:ai:example.com:skill:{index}",
+                        "identifier": f"urn:air:example.com:skill:{index}",
                         "displayName": f"Example Skill {index}",
                         "url": f"https://example.com/{index}/SKILL.md",
                         "score": 91,

--- a/tests/test_hf_spaces.py
+++ b/tests/test_hf_spaces.py
@@ -107,7 +107,7 @@ class RegistrySearchHandler(BaseHTTPRequestHandler):
         response = {
             "results": [
                 {
-                    "identifier": "urn:ai:example.com:skill:image",
+                    "identifier": "urn:air:example.com:skill:image",
                     "displayName": "Image Skill",
                     "type": "application/ai-skill",
                     "url": "https://example.com/SKILL.md",
@@ -240,7 +240,7 @@ class RecordingSearch:
         )
         return [
             SearchResult(
-                identifier="urn:ai:huggingface.co:skill:space:alice:image-tool",
+                identifier="urn:air:huggingface.co:skill:space:alice:image-tool",
                 displayName="Image Tool",
                 type=media_type,
                 url=url,
@@ -260,7 +260,7 @@ class RecordingSkillsSearch:
         self.queries.append((query, limit))
         return [
             SearchResult(
-                identifier="urn:ai:github.com:huggingface:skills:hf-cli",
+                identifier="urn:air:github.com:huggingface:skills:hf-cli",
                 displayName="hf-cli",
                 type=AI_SKILL_MEDIA_TYPE,
                 url="https://github.com/huggingface/skills/blob/main/skills/hf-cli/SKILL.md",
@@ -327,7 +327,7 @@ def test_space_to_search_result_defaults_to_skill_wrapper() -> None:
     space = Space(id="alice/cool.space", tags=["image-to-image"], runtime=Runtime(stage="RUNNING"))
     result = space_to_search_result(cast("SpaceSearchResultLike", space))
 
-    assert result.identifier == "urn:ai:huggingface.co:skill:space:alice:cool.space"
+    assert result.identifier == "urn:air:huggingface.co:skill:space:alice:cool.space"
     assert result.displayName == "Image Tool"
     assert result.type == AI_SKILL_MEDIA_TYPE
     assert result.url == (f"{SPACES_URL_PREFIX}/skills/huggingface/alice/cool.space/SKILL.md")
@@ -362,7 +362,7 @@ def test_space_to_search_result_can_return_generic_space_descriptor() -> None:
     space = Space(id="alice/cool.space")
     result = space_to_search_result(cast("SpaceSearchResultLike", space), kind="space")
 
-    assert result.identifier == "urn:ai:huggingface.co:space:alice:cool.space"
+    assert result.identifier == "urn:air:huggingface.co:space:alice:cool.space"
     assert result.type == HF_SPACE_MEDIA_TYPE
     assert result.url is None
     assert result.data is not None
@@ -681,7 +681,7 @@ def test_hf_skills_search_queries_meili_and_groups_section_hits_by_skill() -> No
         "showRankingScoreDetails": False,
     }
     assert len(results) == 1
-    assert results[0].identifier == "urn:ai:github.com:huggingface:skills:hf-cli"
+    assert results[0].identifier == "urn:air:github.com:huggingface:skills:hf-cli"
     assert results[0].url == "https://github.com/huggingface/skills/tree/main/skills/hf-cli"
     assert results[0].metadata["sourceUrl"] == (
         "https://github.com/huggingface/skills/tree/main/skills/hf-cli"
@@ -896,7 +896,7 @@ def test_discover_search_filters_by_capability_array_values() -> None:
     def search_spaces(query: str, **kwargs: object) -> list[SearchResult]:
         return [
             SearchResult(
-                identifier="urn:ai:huggingface.co:mcp:space:alice:image-tool",
+                identifier="urn:air:huggingface.co:mcp:space:alice:image-tool",
                 displayName="Image Tool",
                 type=MCP_SERVER_MEDIA_TYPE,
                 url="https://example.com/server.json",
@@ -935,7 +935,7 @@ def test_discover_search_returns_spaces_referral_when_requested() -> None:
 
     assert response.results == []
     assert [referral.identifier for referral in response.referrals] == [
-        "urn:ai:huggingface.co:registry:spaces"
+        "urn:air:huggingface.co:registry:spaces"
     ]
     assert (
         response.referrals[0].url
@@ -987,7 +987,7 @@ def test_primary_server_exposes_v5_ai_catalog_well_known_document() -> None:
     assert all("mediaType" not in entry for entry in entries)
     assert entries == [
         {
-            "identifier": "urn:ai:huggingface.co:registry:discover",
+            "identifier": "urn:air:huggingface.co:registry:discover",
             "displayName": "Hugging Face Discover Registry",
             "type": "application/ai-registry+json",
             "url": "http://testserver",
@@ -995,7 +995,7 @@ def test_primary_server_exposes_v5_ai_catalog_well_known_document() -> None:
             "tags": ["huggingface", "registry", "search"],
         },
         {
-            "identifier": "urn:ai:huggingface.co:registry:spaces",
+            "identifier": "urn:air:huggingface.co:registry:spaces",
             "displayName": "Hugging Face Spaces Registry",
             "type": "application/ai-registry+json",
             "url": "http://testserver/registries/huggingface/spaces",

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -32,7 +32,7 @@ class RecordingSkillsSearch:
         self.queries.append((query, limit))
         return [
             SearchResult(
-                identifier="urn:ai:github.com:huggingface:skills:image",
+                identifier="urn:air:github.com:huggingface:skills:image",
                 displayName="Image Skill",
                 type=AI_SKILL_MEDIA_TYPE,
                 url="https://github.com/huggingface/skills/tree/main/skills/image",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,11 +9,24 @@ from discover.models import CatalogEntry, SearchResult
 
 def test_catalog_entry_requires_domain_anchored_urn_identifier() -> None:
     entry = CatalogEntry(
-        identifier="urn:ai:example.com:skill:image-editor",
+        identifier="urn:air:example.com:skill:image-editor",
         displayName="Image Editor",
         type=AI_SKILL_MEDIA_TYPE,
         url="https://example.com/SKILL.md",
     )
+
+    assert entry.identifier == "urn:air:example.com:skill:image-editor"
+
+
+def test_catalog_entry_accepts_legacy_urn_ai_prefix_with_deprecation_warning() -> None:
+    # DEPRECATED(urn:ai): remove with urn:ai support.
+    with pytest.warns(DeprecationWarning, match=r"urn:ai:"):
+        entry = CatalogEntry(
+            identifier="urn:ai:example.com:skill:image-editor",
+            displayName="Image Editor",
+            type=AI_SKILL_MEDIA_TYPE,
+            url="https://example.com/SKILL.md",
+        )
 
     assert entry.identifier == "urn:ai:example.com:skill:image-editor"
 
@@ -22,7 +35,7 @@ def test_catalog_entry_requires_domain_anchored_urn_identifier() -> None:
     "identifier",
     [
         "urn:test:skill:image-editor",
-        "urn:ai:example:skill:image-editor",
+        "urn:air:example:skill:image-editor",
         "https://example.com/skill/image-editor",
     ],
 )
@@ -39,7 +52,7 @@ def test_catalog_entry_rejects_non_ard_identifiers(identifier: str) -> None:
 def test_search_result_score_must_be_relevance_percentage() -> None:
     with pytest.raises(ValidationError):
         SearchResult(
-            identifier="urn:ai:example.com:skill:image-editor",
+            identifier="urn:air:example.com:skill:image-editor",
             displayName="Image Editor",
             type=AI_SKILL_MEDIA_TYPE,
             url="https://example.com/SKILL.md",

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from threading import Thread
 
@@ -120,7 +121,7 @@ def test_parse_navigate_args_accepts_explicit_url_and_multi_word_query() -> None
 
 def result(identifier: str, source: str, score: int) -> SearchResult:
     return SearchResult(
-        identifier=f"urn:ai:example.com:skill:{identifier}",
+        identifier=f"urn:air:example.com:skill:{identifier}",
         displayName=identifier,
         type="application/ai-skill",
         url=f"https://example.com/{identifier}",
@@ -194,3 +195,52 @@ def test_cli_navigate_shows_discovered_registry_url() -> None:
     assert f"{base_url}/.well-known/ai-catalog.json" in result.output
     assert f"{base_url}/registry/search" in result.output
     assert "Image Skill" in result.output
+
+
+def test_navigate_warns_when_external_entries_use_legacy_urn_ai_prefix() -> None:
+    # DEPRECATED(urn:ai): remove with urn:ai support.
+    server, base_url = serve_navigation_fixture()
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", DeprecationWarning)
+            navigate(base_url, "generate image", kind="skill", limit=3)
+    finally:
+        server.shutdown()
+
+    legacy_warnings = [
+        record
+        for record in caught
+        if issubclass(record.category, DeprecationWarning) and "urn:ai:" in str(record.message)
+    ]
+    catalog_url = f"{base_url}/.well-known/ai-catalog.json"
+    registry_url = f"{base_url}/registry/search"
+    messages = [str(record.message) for record in legacy_warnings]
+    assert any(
+        "urn:ai:example.com:registry:tools" in message and catalog_url in message
+        for message in messages
+    )
+    assert any(
+        "urn:ai:example.com:skill:image" in message and registry_url in message
+        for message in messages
+    )
+
+
+def test_navigate_dedupes_legacy_urn_warning_per_source_within_traversal() -> None:
+    # DEPRECATED(urn:ai): remove with urn:ai support.
+    server, base_url = serve_navigation_fixture()
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", DeprecationWarning)
+            navigate(base_url, "generate image", kind="skill", limit=3)
+    finally:
+        server.shutdown()
+
+    catalog_url = f"{base_url}/.well-known/ai-catalog.json"
+    catalog_messages = [
+        str(record.message)
+        for record in caught
+        if issubclass(record.category, DeprecationWarning)
+        and "urn:ai:example.com:registry:tools" in str(record.message)
+        and catalog_url in str(record.message)
+    ]
+    assert len(catalog_messages) == 1


### PR DESCRIPTION
## Summary

The ARD spec renamed the URN namespace from `urn:ai:` to `urn:air:`. See https://github.com/ards-project/ard-spec/pull/39#issuecomment-4775550324 for more context as to how I landed here.

I'm happy to rework this to drop `urn:ai` entirely if we want to go this route, but I figured supporting both for a bit would help others like myself

This PR makes hf-discover speak the new prefix everywhere it mints
identifiers and continues to accept the legacy `urn:ai:` form during
the transition, with a `DeprecationWarning` on every legacy identifier
it parses or discovers.

- emit `urn:air:` from every identifier mint site
  (`hf_spaces`, `hf_skills`, `challenge`, server registry entries)
- `CatalogEntry` validator accepts both prefixes; legacy hits emit
  `DeprecationWarning` via `warnings.warn(..., stacklevel=2)`
- `publisher_from_identifier` accepts both `urn:air:` and `urn:ai:`
  publisher segments
- navigation emits a per-traversal, per-`(identifier, source)` warning
  when a fetched `.well-known/ai-catalog.json` entry or a federated
  `SearchResponse` result/referral still uses `urn:ai:`
- CLI entrypoint flips `warnings.filterwarnings("default", ...)` for
  `discover.*` so the deprecation reaches stderr in interactive runs
- every legacy code path is tagged `# DEPRECATED(urn:ai)` so removal
  is a single `git grep "DEPRECATED(urn:ai)"` sweep
- README updated to mention `urn:air:` as canonical and `urn:ai:` as a
  warned-on transition form
- `spec/ard.md` updated to use `urn:air:` (25 occurrences). Happy to
  drop this hunk if you'd prefer the orientation snapshot to be
  re-synced from the upstream spec checkout instead of edited in
  place — flagging because the README calls out that workflow.

The validator still rejects everything that is neither prefix, and
the FQDN publisher rule is still enforced under the new prefix
(parametrized rejection test updated to `urn:air:example:...`).